### PR TITLE
Issue69 within statement

### DIFF
--- a/lib/jsonquery.js
+++ b/lib/jsonquery.js
@@ -18,7 +18,8 @@ function simplifyModelicaJSON (model, parseMode) {
     logger.error(msg)
     throw new Error(msg)
   }
-  const within = model.within ? model.within[0] : undefined
+  const within = model.within ? model.within[0] : ""
+  console.log(within);
   const pubParameters = this.getParameters(model, 'public')
   const proParameters = this.getParameters(model, 'protected')
 

--- a/lib/jsonquery.js
+++ b/lib/jsonquery.js
@@ -18,7 +18,7 @@ function simplifyModelicaJSON (model, parseMode) {
     logger.error(msg)
     throw new Error(msg)
   }
-  const within = model.within ? model.within[0] : ""
+  const within = model.within ? model.within[0] : ''
   const pubParameters = this.getParameters(model, 'public')
   const proParameters = this.getParameters(model, 'protected')
 

--- a/lib/jsonquery.js
+++ b/lib/jsonquery.js
@@ -19,7 +19,6 @@ function simplifyModelicaJSON (model, parseMode) {
     throw new Error(msg)
   }
   const within = model.within ? model.within[0] : ""
-  console.log(within);
   const pubParameters = this.getParameters(model, 'public')
   const proParameters = this.getParameters(model, 'protected')
 

--- a/schema-CDL.json
+++ b/schema-CDL.json
@@ -864,7 +864,7 @@
   "items": {
     "type": "object",
     "required": [
-      "modelicaFile",
+      "within",
       "topClassName",
       "icon",
       "svg"
@@ -877,7 +877,7 @@
         "pattern": ".*.(mo|MO)"
       },
       "within": {
-        "description": "Within statement from the Modelica file : no special characters or spaces",
+        "description": "Within statement from the Modelica file : no special characters or spaces. If empty string, it is probably a package file",
         "type": "string",
         "pattern": "^([a-zA-Z0-9._*]*)$"
       },

--- a/schema-CDL.json
+++ b/schema-CDL.json
@@ -877,7 +877,7 @@
         "pattern": ".*.(mo|MO)"
       },
       "within": {
-        "description": "Within statement from the Modelica file : no special characters or spaces. If empty string, it is probably a package file",
+        "description": "Within statement from the Modelica file : no special characters or spaces. If empty string, it may be a package file",
         "type": "string",
         "pattern": "^([a-zA-Z0-9._*]*)$"
       },

--- a/schema-modelica.json
+++ b/schema-modelica.json
@@ -851,7 +851,7 @@
   "items": {
     "type": "object",
     "required": [
-      "modelicaFile",
+      "within",
       "topClassName"
     ],
     "additionalProperties": true,
@@ -862,7 +862,7 @@
         "pattern": ".*.(mo|MO)"
       },
       "within": {
-        "description": "Within statement from the Modelica file : no special characters or spaces",
+        "description": "Within statement from the Modelica file : no special characters or spaces. If empty string, it is probably a package file.",
         "type": "string",
         "pattern": "^([a-zA-Z0-9._*]*)$"
       },

--- a/schema-modelica.json
+++ b/schema-modelica.json
@@ -862,7 +862,7 @@
         "pattern": ".*.(mo|MO)"
       },
       "within": {
-        "description": "Within statement from the Modelica file : no special characters or spaces. If empty string, it is probably a package file.",
+        "description": "Within statement from the Modelica file : no special characters or spaces. If empty string, it may be a package file.",
         "type": "string",
         "pattern": "^([a-zA-Z0-9._*]*)$"
       },

--- a/test/FromModelica/cdl/json/FromModelica.package.json
+++ b/test/FromModelica/cdl/json/FromModelica.package.json
@@ -1,6 +1,7 @@
 [
   {
     "modelicaFile": "./package.mo",
+    "within": "",
     "topClassName": "FromModelica",
     "comment": "Package with test models",
     "public": {

--- a/test/FromModelica/modelica/json/FromModelica.package.json
+++ b/test/FromModelica/modelica/json/FromModelica.package.json
@@ -1,6 +1,7 @@
 [
   {
     "modelicaFile": "FromModelica/package.mo",
+    "within": "",
     "topClassName": "FromModelica",
     "comment": "Package with test models",
     "public": {


### PR DESCRIPTION
The 'within' statement used to disappear in the (simplified) JSON format when there was no value in the mo file.

Now, it is parsed as an empty string : {"within" : '' }

-   **jsonquery.js** : added a within property even if the property is empty in the modelica file
- **schema-CDL.json** : added within, deleted modelicaFile from required properties
- **schema-modelica.json** : added within, deleted modelicaFile from required properties