### PR TITLE
fixed winston to version 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mustache": "^2.3.0",
     "promise-fs": "^1.3.0",
     "svg-to-img": "^2.0.9",
-    "winston": "^2.4.0"
+    "winston": "2.4.4"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
This closes #113. 
- [x] fixed the `winston` version to 2.4.4