### PR TITLE
corrected error in relativePath()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -133,8 +133,7 @@ function relativePath (filePath) {
   var paths = getMODELICAPATH()
   var bases = []
   paths.forEach(ele => {
-    var temp = path.parse(ele).base
-    if (temp.length > 0) bases.push(temp)
+    if (ele.length > 0) bases.push(ele)
   })
   var relPa = filePath
   for (var i = 0; i < bases.length; i++) {


### PR DESCRIPTION
Closes #201 . 

Instead of just searching for relativePath based on "base" of directories within MODELICAPATH and current working directory, use the absolute path of these directories to obtain the relativePath. 

Example:
* File: ``/Users/user/modelica-json-2/modelica-json/test/File.mo``
* Current working directory: ``/Users/user/modelica-json-2/modelica-json`` 

Previously: 
* relativePath: ``2/modelica-json/test/File.mo``

After fix
* relativePath: ``test/File.mo``