### PR TITLE
Issue203 logical expression

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,13 +8,13 @@ const path = require('path')
 const ArgumentParser = require('argparse').ArgumentParser
 /// ///////////////////////////////////////
 
-var parser = new ArgumentParser({
+const parser = new ArgumentParser({
   version: '0.0.1',
   addHelp: true,
   description: 'Modelica parser'
 })
 parser.addArgument(
-  [ '-o', '--output' ],
+  ['-o', '--output'],
   {
     help: 'Specify output format.',
     choices: ['raw-json', 'json', 'modelica'],
@@ -22,7 +22,7 @@ parser.addArgument(
   }
 )
 parser.addArgument(
-  [ '-l', '--log' ],
+  ['-l', '--log'],
   {
     help: "Logging level, 'info' is the default.",
     choices: ['error', 'warn', 'info', 'verbose', 'debug'],
@@ -30,7 +30,7 @@ parser.addArgument(
   }
 )
 parser.addArgument(
-  [ '-m', '--mode' ],
+  ['-m', '--mode'],
   {
     help: "Parsing mode, CDL model or a package of the Modelica Buildings library, 'cdl' is the default.",
     choices: ['cdl', 'modelica'],
@@ -38,14 +38,14 @@ parser.addArgument(
   }
 )
 parser.addArgument(
-  [ '-f', '--file' ],
+  ['-f', '--file'],
   {
     help: "Filename or packagename that contains the top-level Modelica class, or a json file when the output format is 'modelica'.",
     required: true
   }
 )
 parser.addArgument(
-  [ '-d', '--directory' ],
+  ['-d', '--directory'],
   {
     help: 'Specify output directory, with the default being the current.',
     defaultValue: 'current'
@@ -54,14 +54,14 @@ parser.addArgument(
 
 parser.addArgument(
 
-  [ '-p', '--prettyPrint' ],
+  ['-p', '--prettyPrint'],
   {
     help: 'Pretty print JSON output.',
     defaultValue: 'false'
   }
 )
 
-var args = parser.parseArgs()
+const args = parser.parseArgs()
 
 const logFile = 'modelica-json.log'
 try {
@@ -92,27 +92,27 @@ if (args.output === 'modelica') {
   pa.convertToModelica(args.file, args.directory, false)
 } else {
   // Get mo files array
-  var moFiles = ut.getMoFiles(args.file)
+  const moFiles = ut.getMoFiles(args.file)
   // Parse the json representation for moFiles
   pa.getJsons(moFiles, args.mode, args.output, args.directory, args.prettyPrint)
 }
 
 if (args.output === 'json') {
-  var schema
+  let schema
   if (args.mode === 'cdl') {
     schema = path.join(`${__dirname}`, 'schema-cdl.json')
   } else {
     schema = path.join(`${__dirname}`, 'schema-modelica.json')
   }
-  var jsonFiles = ut.findFilesInDir(path.join(args.directory, 'json'), '.json')
+  let jsonFiles = ut.findFilesInDir(path.join(args.directory, 'json'), '.json')
   // exclude CDL folder and possibly Modelica folder
-  var pathSep = path.sep
-  var cdlPath = path.join(pathSep, 'CDL', pathSep)
-  var modelicaPath = path.join('Modelica', pathSep)
+  const pathSep = path.sep
+  const cdlPath = path.join(pathSep, 'CDL', pathSep)
+  const modelicaPath = path.join('Modelica', pathSep)
   jsonFiles = jsonFiles.filter(obj => !(obj.includes(cdlPath) || obj.includes(modelicaPath)))
   // validate json schema
-  // for (var i = 0; i < jsonFiles.length; i++) {
-  //   var eachFile = jsonFiles[i]
-  //   setTimeout(function () { ut.jsonSchemaValidation(args.mode, eachFile, 'json', schema) }, 100)
-  // }
+  for (let i = 0; i < jsonFiles.length; i++) {
+    const eachFile = jsonFiles[i]
+    setTimeout(function () { ut.jsonSchemaValidation(args.mode, eachFile, schema) }, 100)
+  }
 }

--- a/app.js
+++ b/app.js
@@ -111,8 +111,8 @@ if (args.output === 'json') {
   var modelicaPath = path.join('Modelica', pathSep)
   jsonFiles = jsonFiles.filter(obj => !(obj.includes(cdlPath) || obj.includes(modelicaPath)))
   // validate json schema
-  for (var i = 0; i < jsonFiles.length; i++) {
-    var eachFile = jsonFiles[i]
-    setTimeout(function () { ut.jsonSchemaValidation(args.mode, eachFile, 'json', schema) }, 100)
-  }
+  // for (var i = 0; i < jsonFiles.length; i++) {
+  //   var eachFile = jsonFiles[i]
+  //   setTimeout(function () { ut.jsonSchemaValidation(args.mode, eachFile, 'json', schema) }, 100)
+  // }
 }

--- a/json2mo/algorithmSection.js
+++ b/json2mo/algorithmSection.js
@@ -1,14 +1,14 @@
 function parse (content, rawJson = false) {
   const statementParser = require('./statement')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.initial != null) {
     if (content.initial) {
       moOutput += 'initial '
     }
   }
   moOutput += 'algorithm'
-  var statements = null
+  let statements = null
   if (rawJson) {
     statements = content.statements
   } else {
@@ -24,4 +24,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/annotation.js
+++ b/json2mo/annotation.js
@@ -1,18 +1,18 @@
 function parse (content, rawJson = false) {
   const classModificationParser = require('./classModification')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += '\n\tannotation '
   if (rawJson) {
     if (content.class_modification != null) {
       moOutput += classModificationParser.parse(content.class_modification, rawJson)
     }
   } else {
-    var classModification = content
+    const classModification = content
     moOutput += classModificationParser.parse(classModification, rawJson)
   }
-    // moOutput+="\n"
+  // moOutput+="\n"
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/argument.js
+++ b/json2mo/argument.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const elementModificationOrReplaceable = require('./elementModificationOrReplaceable')
   const elementRedeclaration = require('./elementRedeclaration')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.element_modification_or_replaceable != null) {
     moOutput += elementModificationOrReplaceable.parse(content.element_modification_or_replaceable, rawJson)
   } else if (content.element_redeclaration != null) {
@@ -11,4 +11,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/argumentList.js
+++ b/json2mo/argumentList.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const argumentParser = require('./argument')
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
-    var argumentStr = content.arguments
+    const argumentStr = content.arguments
 
     if (argumentStr != null) {
       argumentStr.forEach(argument => {
@@ -15,4 +15,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/arraySubscripts.js
+++ b/json2mo/arraySubscripts.js
@@ -2,11 +2,11 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const subscriptParser = require('./subscript')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (rawJson) {
     moOutput += '['
-    var subscripts = content.subscripts
+    const subscripts = content.subscripts
     if (subscripts != null) {
       subscripts.forEach(subscript => {
         moOutput += subscriptParser.parse(subscript, rawJson)
@@ -16,7 +16,7 @@ function parse (content, rawJson = false) {
     }
     moOutput += '] '
   } else {
-    var arraySubscripts = content
+    const arraySubscripts = content
     moOutput += '['
 
     if (arraySubscripts != null) {
@@ -37,4 +37,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/assignmentEquation.js
+++ b/json2mo/assignmentEquation.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const simpleExpression = require('./simpleExpression')
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.lhs != null) {
     moOutput += simpleExpression.parse(content.lhs, rawJson)
   }
@@ -13,4 +13,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/assignmentStatement.js
+++ b/json2mo/assignmentStatement.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const componentReferenceParser = require('./componentReference')
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.identifier != null) {
     moOutput += componentReferenceParser.parse(content.identifier, rawJson)
   }
@@ -13,4 +13,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/assignmentWithFunctionCallStatement.js
+++ b/json2mo/assignmentWithFunctionCallStatement.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const outputExpressionListParser = require('./outputExpressionList')
   const functionCallArgsParser = require('./functionCallArgs')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += '('
   if (content.output_expression_list != null) {
     moOutput += outputExpressionListParser.parse(content.output_expression_list, rawJson)
@@ -19,4 +19,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/basePrefix.js
+++ b/json2mo/basePrefix.js
@@ -1,12 +1,12 @@
 function parse (content, rawJson = false) {
   const util = require('util')
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     if (content.type_prefix != null) {
       moOutput += util.format('%s ', content.type_prefix)
     }
   } else {
-    var basePrefix = content
+    const basePrefix = content
     if (basePrefix != null) {
       moOutput += util.format('%s ', basePrefix)
     }
@@ -15,4 +15,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/classDefinition.js
+++ b/json2mo/classDefinition.js
@@ -1,9 +1,9 @@
 function parse (content, rawJson = false) {
   const util = require('util')
   const classSpecifier = require('./classSpecifier')
-  var encapsulated = content.encapsulated
-  var classPrefixes = content.class_prefixes
-  var moOutput = ''
+  const encapsulated = content.encapsulated
+  const classPrefixes = content.class_prefixes
+  let moOutput = ''
 
   if (encapsulated != null) {
     if (encapsulated) {
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/classModification.js
+++ b/json2mo/classModification.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const argumentListParser = require('./argumentList')
   const argumentParser = require('./argument')
 
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     moOutput += '(\n\t'
     if (content.argument_list != null) {
@@ -10,7 +10,7 @@ function parse (content, rawJson = false) {
     }
     moOutput += ')\n\t'
   } else {
-    var argumentList = content
+    const argumentList = content
     moOutput += '(\n\t'
 
     argumentList.forEach(argument => {
@@ -24,4 +24,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/classSpecifier.js
+++ b/json2mo/classSpecifier.js
@@ -3,11 +3,11 @@ function parse (content, rawJson = false) {
   const shortClassSpecifierParser = require('./shortClassSpecifier')
   const derClassSpecifierParser = require('./derClassSpecifier')
 
-  var longClassSpecifier = content.long_class_specifier
-  var shortClassSpecifier = content.short_class_specifier
-  var derClassSpecifier = content.der_class_specifier
+  const longClassSpecifier = content.long_class_specifier
+  const shortClassSpecifier = content.short_class_specifier
+  const derClassSpecifier = content.der_class_specifier
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (longClassSpecifier != null) {
     moOutput += longClassSpecifierParser.parse(longClassSpecifier, rawJson)
@@ -24,4 +24,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/comment.js
+++ b/json2mo/comment.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const annotationParser = require('./annotation')
 
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     if (content.string_comment != null) {
       moOutput += util.format('\n"\t%s"', content.string_comment)
@@ -22,4 +22,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentClause.js
+++ b/json2mo/componentClause.js
@@ -4,7 +4,7 @@ function parse (content, rawJson = false) {
   const componentListParser = require('./componentList')
   const util = require('util')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.type_prefix != null) {
     moOutput += util.format('%s ', content.type_prefix)
@@ -28,4 +28,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentClause1.js
+++ b/json2mo/componentClause1.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const typeSpecifierParser = require('./typeSpecifier')
   const componentDeclaration1Parser = require('./componentDeclaration1')
 
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     if (content.type_prefix != null) {
       moOutput += util.format('%s ', content.type_prefix)
@@ -29,4 +29,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentDeclaration.js
+++ b/json2mo/componentDeclaration.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const conditionAttributeParser = require('./condition_attribute')
   const commentParser = require('./comment')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.declaration != null) {
     moOutput += declarationParser.parse(content.declaration, rawJson)
   }
@@ -16,4 +16,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentDeclaration1.js
+++ b/json2mo/componentDeclaration1.js
@@ -2,7 +2,7 @@ function parse (content, rawJson) {
   const declarationParser = require('./declaration')
   const commentParser = require('./comment')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.declaration != null) {
     moOutput += declarationParser.parse(content.declaration, rawJson)
   }
@@ -18,4 +18,4 @@ function parse (content, rawJson) {
 
   return moOutput
 }
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentList.js
+++ b/json2mo/componentList.js
@@ -4,8 +4,8 @@ function parse (content, rawJson = false) {
   const conditionAttributeParser = require('./conditionAttribute')
   const commentParser = require('./comment')
 
-  var moOutput = ''
-  var componentDeclarationList
+  let moOutput = ''
+  let componentDeclarationList
   if (rawJson) {
     componentDeclarationList = content.component_declaration_list
 
@@ -30,4 +30,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentReference.js
+++ b/json2mo/componentReference.js
@@ -3,8 +3,8 @@ function parse (content, rawJson = false) {
   const arraySubscriptsParser = require('./arraySubscripts')
   const componentReferencePartParser = require('./componentReferencePart')
 
-  var moOutput = ''
-  var componentReferenceParts
+  let moOutput = ''
+  let componentReferenceParts
   if (rawJson) {
     componentReferenceParts = content.component_reference_parts
     if (componentReferenceParts != null) {
@@ -31,4 +31,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/componentReferencePart.js
+++ b/json2mo/componentReferencePart.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const arraySubscriptsParser = require('./arraySubscripts')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (rawJson) {
     if (content.dot_op != null) {
@@ -20,4 +20,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/composition.js
+++ b/json2mo/composition.js
@@ -4,12 +4,12 @@ function parse (content, rawJson = false) {
   const externalCompositionParser = require('./externalComposition')
   const annotationParser = require('./annotation')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.element_list != null) {
     moOutput += elementListParser.parse(content.element_list, rawJson)
   }
   if (content.element_sections != null) {
-    var elementSections = content.element_sections
+    const elementSections = content.element_sections
     elementSections.forEach(ele => {
       moOutput += elementSectionParser.parse(ele, rawJson)
     })
@@ -24,4 +24,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/conditionAttribute.js
+++ b/json2mo/conditionAttribute.js
@@ -1,14 +1,14 @@
 function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += '\n\tif '
   if (rawJson) {
     if (content.expression != null) {
       moOutput += expressionParser.parse(content.expression, rawJson)
     }
   } else {
-    var expression = content
+    const expression = content
     if (expression != null) {
       moOutput += expressionParser.parse(expression, rawJson)
     }
@@ -16,4 +16,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/connectClause.js
+++ b/json2mo/connectClause.js
@@ -1,7 +1,7 @@
 function parse (content, rawJson = false) {
   const componentReferenceParser = require('./componentReference')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'connect('
   if (content.from != null) {
     moOutput += componentReferenceParser.parse(content.from, rawJson)
@@ -14,4 +14,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/constrainingClause.js
+++ b/json2mo/constrainingClause.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const nameParser = require('./name')
   const classModificationParser = require('./classModification')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'constrainedby '
 
   if (content.name != null) {
@@ -14,4 +14,4 @@ function parse (content, rawJson = false) {
   }
   return moOutput
 }
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/declaration.js
+++ b/json2mo/declaration.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const arraySubscriptsParser = require('./arraySubscripts')
   const modificationParser = require('./modification')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.identifier != null) {
     moOutput += util.format('%s', content.identifier)
   }
@@ -16,4 +16,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/derClassSpecifier.js
+++ b/json2mo/derClassSpecifier.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const derClassSpecifierValueParser = require('./derClassSpecifierValue')
 
-  var moOutput = ''
-  var identifier = content.identifier
+  let moOutput = ''
+  const identifier = content.identifier
 
   if (identifier != null) {
     moOutput += util.format('%s= ', identifier)
@@ -22,4 +22,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/derClassSpecifierValue.js
+++ b/json2mo/derClassSpecifierValue.js
@@ -3,11 +3,11 @@ function parse (content, rawJson = false) {
   const nameParser = require('./name')
   const commentParser = require('./comment')
 
-  var moOutput = 'der('
+  let moOutput = 'der('
   if (content.type_specifier != null) {
     moOutput += nameParser.parse(content.type_specifier, rawJson)
   }
-  var identifiers = null
+  let identifiers = null
   if (rawJson) {
     identifiers = content.identifiers
   } else {
@@ -33,4 +33,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/element.js
+++ b/json2mo/element.js
@@ -6,7 +6,7 @@ function parse (content, rawJson = false) {
   const constrainingClauseParser = require('./constrainingClause')
   const commentParser = require('./comment')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.import_clause != null) {
     moOutput += importClauseParser.parse(content.import_clause, rawJson)
     moOutput += ';\n'
@@ -84,4 +84,4 @@ function parse (content, rawJson = false) {
   }
   return moOutput
 }
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/elementList.js
+++ b/json2mo/elementList.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const elementParser = require('./element')
 
-  var moOutput = ''
-  var elements
+  let moOutput = ''
+  let elements
   if (rawJson) {
     elements = content.elements
     if (elements != null) {
@@ -22,4 +22,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/elementModification.js
+++ b/json2mo/elementModification.js
@@ -6,14 +6,14 @@ function parse (content, rawJson = false) {
   const graPri = require('../lib/graphicalPrimitives.js')
 
   // Get all the keys in the json object. It may be graphical primitive.
-  var keys = Object.keys(content)
-  var isGraPri = false
+  const keys = Object.keys(content)
+  let isGraPri = false
   // check if it is a graphical primitive
   isGraPri = keys.some(function (ele) {
     return graPri.isGraphicAnnotation(ele)
   })
 
-  var moOutput = ''
+  let moOutput = ''
   if (isGraPri) {
     moOutput += graphicParser.parse(content, rawJson)
   } else {
@@ -31,4 +31,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/elementModificationOrReplaceable.js
+++ b/json2mo/elementModificationOrReplaceable.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const elementModificationParser = require('./elementModification')
   const elementReplaceableParser = require('./elementReplaceable')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.each != null) {
     if (content.each) {
       moOutput += 'each '
@@ -30,4 +30,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/elementRedeclaration.js
+++ b/json2mo/elementRedeclaration.js
@@ -3,7 +3,7 @@ function parse (content, rawJson) {
   const componentClause1Parser = require('./componentClause1')
   const elementReplaceableParser = require('./elementReplaceable')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'redeclare '
 
   if (content.each != null) {
@@ -36,4 +36,4 @@ function parse (content, rawJson) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/elementReplaceable.js
+++ b/json2mo/elementReplaceable.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const componentClause1Parser = require('./componentClause1')
   const constrainingClauseParser = require('./constrainingClause')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'replaceable '
   if (content.short_class_definition != null) {
     moOutput += shortClassDefinitionParser.parse(content.short_class_definition, rawJson)
@@ -16,4 +16,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/elementSection.js
+++ b/json2mo/elementSection.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const equationSectionParser = require('./equationSection')
   const algorithmSectionParser = require('./algorithmSection')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.public_element_list != null) {
     moOutput += 'public\n'
@@ -19,4 +19,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/enumList.js
+++ b/json2mo/enumList.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const enumerationLiteralParser = require('./enumerationLiteral')
 
-  var moOutput = ''
-  var enumerationLiterals
+  let moOutput = ''
+  let enumerationLiterals
   if (rawJson) {
     enumerationLiterals = content.enumeration_literal
   } else {
@@ -19,4 +19,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/enumerationLiteral.js
+++ b/json2mo/enumerationLiteral.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const commentParser = require('./comment')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.identifier != null) {
     moOutput += util.format('%s ', content.identifier)
@@ -20,4 +20,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/equation.js
+++ b/json2mo/equation.js
@@ -7,7 +7,7 @@ function parse (content, rawJson = false) {
   const functionCallEquationParser = require('./functionCallEquation')
   const commentParser = require('./comment')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.assignment_equation != null) {
     moOutput += '\n'
     moOutput += assignmentEquationParser.parse(content.assignment_equation, rawJson)
@@ -41,4 +41,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/equationSection.js
+++ b/json2mo/equationSection.js
@@ -1,14 +1,14 @@
 function parse (content, rawJson = false) {
   const equationParser = require('./equation')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.initial != null) {
     if (content.initial) {
       moOutput += 'initial '
     }
   }
   moOutput += 'equation'
-  var equations
+  let equations
   if (rawJson) {
     equations = content.equations
   } else {
@@ -23,4 +23,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/expression.js
+++ b/json2mo/expression.js
@@ -1,7 +1,7 @@
 function parse (content, rawJson = false) {
   const simpleExpressionParser = require('./simpleExpression')
   const ifExpressionParser = require('./ifExpression')
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.if_expression != null) {
     moOutput += ifExpressionParser.parse(content.if_expression, rawJson)
@@ -12,4 +12,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/expressionList.js
+++ b/json2mo/expressionList.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
 
-  var moOutput = ''
-  var expressionList = null
+  let moOutput = ''
+  let expressionList = null
   if (rawJson) {
     expressionList = content.expressions
   } else {
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/extendsClause.js
+++ b/json2mo/extendsClause.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const classModificationParser = require('./classModification')
   const annotationParser = require('./annotation')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'extends '
 
   if (content.name != null) {
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/externalComposition.js
+++ b/json2mo/externalComposition.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const externalFunctionCallParser = require('./externalFunctionCall')
   const annotationParser = require('./annotation')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'external '
   if (content.language_specification != null) {
     moOutput += util.format('%s ', content.language_specification)
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/externalFunctionCall.js
+++ b/json2mo/externalFunctionCall.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const componentReferenceParser = require('./componentReference')
   const expressionListParser = require('./expressionList')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.component_reference != null) {
     moOutput += componentReferenceParser.parse(content.component_reference, rawJson)
@@ -19,4 +19,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/finalClassDefinition.js
+++ b/json2mo/finalClassDefinition.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const classDefinitionParser = require('./classDefinition')
 
-  var moOutput = ''
-  var isFinal = false
+  let moOutput = ''
+  let isFinal = false
 
   if (rawJson) {
     isFinal = content.is_final
@@ -20,11 +20,11 @@ function parse (content, rawJson = false) {
       moOutput += classDefinitionParser.parse(content.class_definition, rawJson)
     }
   } else {
-    var classDefinition = content
+    const classDefinition = content
     moOutput += classDefinitionParser.parse(classDefinition, rawJson)
   }
 
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/forEquation.js
+++ b/json2mo/forEquation.js
@@ -2,16 +2,15 @@ function parse (content, rawJson = false) {
   const forIndicesParser = require('./forIndices')
   const equationParser = require('./equation')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'for '
-  var loopEquations
   if (content.for_indices != null) {
     moOutput += forIndicesParser.parse(content.for_indices, rawJson)
   }
 
   moOutput += 'loop \n'
 
-  loopEquations = content.loop_equations
+  const loopEquations = content.loop_equations
   loopEquations.forEach(ele => {
     moOutput += equationParser.parse(ele, rawJson)
     moOutput += ';\n'
@@ -20,4 +19,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/forIndex.js
+++ b/json2mo/forIndex.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     if (content.identifier != null) {
       moOutput += util.format('%s ', content.identifier)
@@ -16,4 +16,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/forIndices.js
+++ b/json2mo/forIndices.js
@@ -3,8 +3,8 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const forIndexParser = require('./forIndex') // only for raw-json
 
-  var moOutput = ''
-  var indices
+  let moOutput = ''
+  let indices
   if (rawJson) {
     indices = content.indices
     if (indices != null) {
@@ -33,4 +33,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/forIndicesObj.js
+++ b/json2mo/forIndicesObj.js
@@ -1,13 +1,13 @@
 function parse (content, rawJson = false) {
   const util = require('util')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += util.format('%s', content[0].name)
   moOutput += ' in '
   moOutput += util.format('%s', content[0].range)
   if (content.length > 1) {
-    for (var i = 1; i < content.length; i++) {
-      var ith = content[i]
+    for (let i = 1; i < content.length; i++) {
+      const ith = content[i]
       moOutput += ', '
       moOutput += util.format('%s', ith.name)
       moOutput += ' in '
@@ -17,4 +17,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/forLoopObj.js
+++ b/json2mo/forLoopObj.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const forIndiceObjParser = require('./forIndicesObj')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content != null) {
     moOutput += '{'
     moOutput += expressionParser.parse(content.expression, rawJson)
@@ -13,4 +13,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/forStatement.js
+++ b/json2mo/forStatement.js
@@ -2,14 +2,14 @@ function parse (content, rawJson = false) {
   const forIndicesParser = require('./for_indices')
   const statementParser = require('./statement')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'for '
   if (content.for_indices != null) {
     moOutput += forIndicesParser.parse(content.for_indices, rawJson)
   }
   moOutput += 'loop \n'
 
-  var loopStatements = content.loop_statements
+  const loopStatements = content.loop_statements
   loopStatements.forEach(ele => {
     moOutput += statementParser.parse(ele, rawJson)
     moOutput += ';\n'
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionArgument.js
+++ b/json2mo/functionArgument.js
@@ -4,7 +4,7 @@ function parse (content, rawJson = false) {
   const namedArgumentParser = require('./namedArgument')
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.function_name != null) {
     moOutput += 'function '
@@ -16,7 +16,7 @@ function parse (content, rawJson = false) {
         moOutput += namedArgumentsParser.parse(content.named_arguments, rawJson)
       }
     } else {
-      var namedArguments = content.named_arguments
+      const namedArguments = content.named_arguments
       if (namedArguments != null) {
         namedArguments.forEach(ele => {
           moOutput += namedArgumentParser.parse(ele, rawJson)
@@ -32,4 +32,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionArguments.js
+++ b/json2mo/functionArguments.js
@@ -5,7 +5,7 @@ function parse (content, rawJson = false) {
   const functionArgumentParser = require('./functionArgument')
   const forIndicesParser = require('./forIndices')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (rawJson) {
     if (content.named_arguments != null) {
@@ -24,7 +24,7 @@ function parse (content, rawJson = false) {
       }
     }
   } else {
-    var namedArguments = content.named_arguments // only in simplified-json
+    const namedArguments = content.named_arguments // only in simplified-json
 
     if (namedArguments != null) {
       namedArguments.forEach(ele => {
@@ -49,4 +49,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionCallArgs.js
+++ b/json2mo/functionCallArgs.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const functionArgumentParser = require('./functionArgument')
   const functionArgumentsParser = require('./functionArguments')
   const forIndicesParser = require('./forIndices')
-  var moOutput = ''
+  let moOutput = ''
   moOutput += '('
 
   if (rawJson) {
@@ -11,7 +11,7 @@ function parse (content, rawJson = false) {
       moOutput += functionArgumentsParser.parse(content.function_arguments, rawJson)
     }
   } else {
-    var namedArguments = content.named_arguments // only in simplified-json
+    const namedArguments = content.named_arguments // only in simplified-json
 
     if (namedArguments != null) {
       namedArguments.forEach(ele => {
@@ -38,4 +38,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionCallArgsObj.js
+++ b/json2mo/functionCallArgsObj.js
@@ -3,7 +3,7 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const forIndiceObjParser = require('./forIndicesObj')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content[0].expression != null) {
     moOutput += expressionParser.parse(content[0].expressoin, rawJson)
     moOutput += ' for '
@@ -20,4 +20,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionCallEquation.js
+++ b/json2mo/functionCallEquation.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const nameParser = require('./name')
   const functionCallArgsParser = require('./functionCallArgs')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.function_name != null) {
     moOutput += nameParser.parse(content.function_name, rawJson)
@@ -14,4 +14,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionCallObj.js
+++ b/json2mo/functionCallObj.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const functionCallArgsObjParser = require('./functionCallArgsObj')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.name != null) {
     moOutput += util.format('%s', content.name)
   }
@@ -14,4 +14,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/functionCallStatement.js
+++ b/json2mo/functionCallStatement.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const componentReferenceParser = require('./componentReference')
   const functionCallArgsParser = require('./functionCallArgs')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.function_name != null) {
     moOutput += componentReferenceParser.parse(content.function_name, rawJson)
   }
@@ -12,4 +12,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/graphic.js
+++ b/json2mo/graphic.js
@@ -3,10 +3,10 @@ const util = require('util')
 function parse (content, rawJson = false) {
   // "keys" will be a one element array, could be
   // ['Line', 'Text', 'Rectangle', 'Polygon', 'Ellipse', 'Bitmap', 'Placement', 'coordinateSystem', 'graphics']
-  var graKeys = Object.keys(content)
-  var graKey = graKeys[0]
+  const graKeys = Object.keys(content)
+  const graKey = graKeys[0]
 
-  var moOutput = ''
+  let moOutput = ''
   if (graKey === 'Line') {
     moOutput += lineParse(content.Line)
   } else if (graKey === 'Text') {
@@ -31,41 +31,41 @@ function parse (content, rawJson = false) {
 }
 
 function lineParse (obj) {
-  var graComIte = commonGraphicItems(obj)
+  const graComIte = commonGraphicItems(obj)
   return 'Line(' + graComIte.join(',') + ')'
 }
 
 function textParse (obj) {
-  var graComIte = commonGraphicItems(obj)
+  const graComIte = commonGraphicItems(obj)
   return 'Text(' + graComIte.join(',') + ')'
 }
 
 function rectangleParse (obj) {
-  var graComIte = commonGraphicItems(obj)
+  const graComIte = commonGraphicItems(obj)
   return 'Rectangle(' + graComIte.join(',') + ')'
 }
 
 function polygonParse (obj) {
-  var graComIte = commonGraphicItems(obj)
+  const graComIte = commonGraphicItems(obj)
   return 'Polygon(' + graComIte.join(',') + ')'
 }
 
 function ellipseParse (obj) {
-  var graComIte = commonGraphicItems(obj)
+  const graComIte = commonGraphicItems(obj)
   return 'Ellipse(' + graComIte.join(',') + ')'
 }
 
 function bitmapParse (obj) {
-  var graComIte = commonGraphicItems(obj)
+  const graComIte = commonGraphicItems(obj)
   return 'Bitmap(' + graComIte.join(',') + ')'
 }
 
 function placementParse (obj) {
-  var visible = obj.visible
-  var iconVisible = obj.iconVisible
-  var transformation = obj.transformation
-  var iconTransformation = obj.iconTransformation
-  var strArr = []
+  const visible = obj.visible
+  const iconVisible = obj.iconVisible
+  const transformation = obj.transformation
+  const iconTransformation = obj.iconTransformation
+  const strArr = []
   if (visible != null) {
     strArr.push('visible=' + util.format('%s', visible))
   }
@@ -82,10 +82,10 @@ function placementParse (obj) {
 }
 
 function coordinateSystemParse (obj) {
-  var extent = obj.extent
-  var preserveAspectRatio = obj.preserveAspectRatio
-  var initialScale = obj.initialScale
-  var strArr = []
+  const extent = obj.extent
+  const preserveAspectRatio = obj.preserveAspectRatio
+  const initialScale = obj.initialScale
+  const strArr = []
   if (extent != null) {
     strArr.push('extent=' + pointsParse(extent))
   }
@@ -99,22 +99,22 @@ function coordinateSystemParse (obj) {
 }
 
 function graphicsParse (obj) {
-  var strArr = []
-  for (var i = 0; i < obj.length; i++) {
-    var ithEle = obj[i]
-    var name = ithEle.name
-    var attibutes = ithEle.attribute
-    var graComIte = commonGraphicItems(attibutes)
+  const strArr = []
+  for (let i = 0; i < obj.length; i++) {
+    const ithEle = obj[i]
+    const name = ithEle.name
+    const attibutes = ithEle.attribute
+    const graComIte = commonGraphicItems(attibutes)
     strArr.push(name + '(' + graComIte.join(',') + ')')
   }
   return 'graphics=' + '{' + strArr.join(',') + '}'
 }
 
 function transformationParse (obj) {
-  var origin = obj.origin
-  var extent = obj.extent
-  var rotation = obj.rotation
-  var strArr = []
+  const origin = obj.origin
+  const extent = obj.extent
+  const rotation = obj.rotation
+  const strArr = []
   if (origin != null) {
     strArr.push('origin=' + originParse(origin))
   }
@@ -128,10 +128,10 @@ function transformationParse (obj) {
 }
 
 function pointsParse (obj) {
-  var pointsArr = []
-  for (var i = 0; i < obj.length; i++) {
-    var ithPoint = obj[i]
-    var pointStr = '{'
+  const pointsArr = []
+  for (let i = 0; i < obj.length; i++) {
+    const ithPoint = obj[i]
+    let pointStr = '{'
     pointStr += util.format('%s', ithPoint.x)
     pointStr += ','
     pointStr += util.format('%s', ithPoint.y)
@@ -142,7 +142,7 @@ function pointsParse (obj) {
 }
 
 function colorParse (obj) {
-  var colEle = '{'
+  let colEle = '{'
   colEle += util.format('%s', obj.r)
   colEle += ','
   colEle += util.format('%s', obj.g)
@@ -153,7 +153,7 @@ function colorParse (obj) {
 }
 
 function originParse (obj) {
-  var ori = '{'
+  let ori = '{'
   ori += util.format('%s', obj.x)
   ori += ','
   ori += util.format('%s', obj.y)
@@ -162,35 +162,35 @@ function originParse (obj) {
 }
 
 function commonGraphicItems (obj) {
-  var color = obj.color
-  var thickness = obj.thickness
-  var arrowSize = obj.arrowSize
-  var extent = obj.extent
-  var textString = obj.textString
-  var fontSize = obj.fontSize
-  var fontName = obj.fontName
-  var textColor = obj.textColor
-  var horizontalAlignment = obj.horizontalAlignment
-  var string = obj.string
-  var index = obj.index
-  var radius = obj.radius
-  var borderPattern = obj.borderPattern
-  var points = obj.points
-  var smooth = obj.smooth
-  var startAngle = obj.startAngle
-  var endAngle = obj.endAngle
-  var closure = obj.closure
-  var fileName = obj.fileName
-  var imageSource = obj.imageSource
-  var visible = obj.visible
-  var origin = obj.origin
-  var rotation = obj.rotation
-  var lineColor = obj.lineColor
-  var fillColor = obj.fillColor
-  var pattern = obj.pattern
-  var fillPattern = obj.fillPattern
-  var lineThickness = obj.lineThickness
-  var strArr = []
+  const color = obj.color
+  const thickness = obj.thickness
+  const arrowSize = obj.arrowSize
+  const extent = obj.extent
+  const textString = obj.textString
+  const fontSize = obj.fontSize
+  const fontName = obj.fontName
+  const textColor = obj.textColor
+  const horizontalAlignment = obj.horizontalAlignment
+  const string = obj.string
+  const index = obj.index
+  const radius = obj.radius
+  const borderPattern = obj.borderPattern
+  const points = obj.points
+  const smooth = obj.smooth
+  const startAngle = obj.startAngle
+  const endAngle = obj.endAngle
+  const closure = obj.closure
+  const fileName = obj.fileName
+  const imageSource = obj.imageSource
+  const visible = obj.visible
+  const origin = obj.origin
+  const rotation = obj.rotation
+  const lineColor = obj.lineColor
+  const fillColor = obj.fillColor
+  const pattern = obj.pattern
+  const fillPattern = obj.fillPattern
+  const lineThickness = obj.lineThickness
+  const strArr = []
   if (fileName != null) {
     strArr.push('fileName=' + util.format('%s', fileName))
   }
@@ -281,4 +281,4 @@ function commonGraphicItems (obj) {
   return strArr
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifElseifEquation.js
+++ b/json2mo/ifElseifEquation.js
@@ -2,14 +2,14 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const equationParser = require('./equation')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.condition != null) {
     moOutput += expressionParser.parse(content.condition, rawJson)
   }
 
-  var thenEquations = content.then
-  var thenOutput = ''
+  const thenEquations = content.then
+  let thenOutput = ''
   if (thenEquations != null) {
     thenOutput = ''
     thenEquations.forEach(ele => {
@@ -24,4 +24,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifElseifExpression.js
+++ b/json2mo/ifElseifExpression.js
@@ -1,7 +1,7 @@
 function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.condition != null) {
     moOutput += expressionParser.parse(content.condition, rawJson)
@@ -14,4 +14,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifElseifStatement.js
+++ b/json2mo/ifElseifStatement.js
@@ -2,14 +2,14 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const statementParser = require('./statement')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.condition != null) {
     moOutput += expressionParser.parse(content.condition, rawJson)
   }
 
-  var thenStatements = content.then
-  var thenOutput = ''
+  const thenStatements = content.then
+  let thenOutput = ''
   if (thenStatements != null) {
     thenOutput = ''
     thenStatements.forEach(ele => {
@@ -24,4 +24,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifEquation.js
+++ b/json2mo/ifEquation.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const ifElseifEquationParser = require('./ifElseifEquation')
   const equationParser = require('./equation')
 
-  var moOutput = ''
-  var ifElseifs = content.if_elseif
+  let moOutput = ''
+  const ifElseifs = content.if_elseif
   if (ifElseifs != null) {
     ifElseifs.forEach(ele => {
       moOutput += 'elseif '
@@ -12,9 +12,9 @@ function parse (content, rawJson = false) {
   }
   moOutput = moOutput.slice(4, moOutput.length) // to remove 1st else of elseif so that we get "if"
 
-  var elseEquations = content.else_equation
+  const elseEquations = content.else_equation
   if (elseEquations != null) {
-    var elseOutput = ''
+    let elseOutput = ''
     elseEquations.forEach(ele => {
       elseOutput += equationParser.parse(ele, rawJson)
       elseOutput += ';\n'
@@ -28,4 +28,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifExpression.js
+++ b/json2mo/ifExpression.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const ifElseifExpressionParser = require('./ifElseifExpression')
   const expressionParser = require('./expression')
 
-  var moOutput = ''
-  var ifElseifs = content.if_elseif
+  let moOutput = ''
+  const ifElseifs = content.if_elseif
   if (ifElseifs != null) {
     ifElseifs.forEach(ele => {
       moOutput += ' elseif '
@@ -19,4 +19,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifExpressionObj.js
+++ b/json2mo/ifExpressionObj.js
@@ -1,14 +1,14 @@
 function parse (content, rawJson = false) {
   const util = require('util')
-  var moOutput = ''
-  for (var i = 0; i < content.length; i++) {
-    var ithCon = content[i]
-    var ithElseIf = ithCon.if_elseif
+  let moOutput = ''
+  for (let i = 0; i < content.length; i++) {
+    const ithCon = content[i]
+    const ithElseIf = ithCon.if_elseif
     moOutput += 'if ('
     moOutput += util.format('%s', ithElseIf[0].condition)
     moOutput += ') then '
     moOutput += util.format('%s', ithElseIf[0].then)
-    for (var j = 1; j < ithElseIf.length; j++) {
+    for (let j = 1; j < ithElseIf.length; j++) {
       moOutput += ' elseif ('
       moOutput += util.format('%s', ithElseIf[j].condition)
       moOutput += ') then '
@@ -23,4 +23,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/ifStatement.js
+++ b/json2mo/ifStatement.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const ifElseifStatementParser = require('./ifElseifStatement')
   const statementParser = require('./statement')
 
-  var moOutput = ''
-  var ifElseifs = content.if_elseif
+  let moOutput = ''
+  const ifElseifs = content.if_elseif
   if (ifElseifs != null) {
     ifElseifs.forEach(ele => {
       moOutput += 'elseif '
@@ -12,9 +12,9 @@ function parse (content, rawJson = false) {
   }
   moOutput = moOutput.slice(4, moOutput.length) // to remove 1st else of elseif so that we get "if"
 
-  var elseStatements = content.else_statement
+  const elseStatements = content.else_statement
   if (elseStatements != null) {
-    var elseOutput = ''
+    let elseOutput = ''
     elseStatements.forEach(ele => {
       elseOutput += statementParser.parse(ele, rawJson)
       elseOutput += ';\n'
@@ -28,4 +28,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/importClause.js
+++ b/json2mo/importClause.js
@@ -4,10 +4,10 @@ function parse (content, rawJson = false) {
   const commentParser = require('./comment')
   const importListParser = require('./importList')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'import '
 
-  var name = ''
+  let name = ''
   if (content.name != null) {
     name = nameParser.parse(content.name, rawJson)
   }
@@ -40,4 +40,4 @@ function parse (content, rawJson = false) {
 
   return moOutput
 }
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/importList.js
+++ b/json2mo/importList.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const util = require('util')
 
-  var moOutput = ''
-  var identifierList = content.identifier_list
+  let moOutput = ''
+  const identifierList = content.identifier_list
   if (identifierList != null) {
     identifierList.forEach(identifier => {
       moOutput += util.format('%s, ', identifier)
@@ -12,4 +12,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/logicalAnd.js
+++ b/json2mo/logicalAnd.js
@@ -1,10 +1,10 @@
 function parse (content, rawJson = false) {
   const logicalFactorObjParser = require('./logicalFactorObj')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += logicalFactorObjParser.parse(content[0], rawJson)
   if (content.length > 1) {
-    for (var i = 1; i < content.length; i++) {
+    for (let i = 1; i < content.length; i++) {
       moOutput += ' and '
       moOutput += logicalFactorObjParser.parse(content[i], rawJson)
     }
@@ -12,4 +12,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/logicalExpression.js
+++ b/json2mo/logicalExpression.js
@@ -1,11 +1,11 @@
 function parse (content, rawJson = false) {
   const logicalAndParser = require('./logicalAnd')
 
-  var logicalOr = content.logical_or
-  var moOutput = ''
+  const logicalOr = content.logical_or
+  let moOutput = ''
   moOutput += logicalAndParser.parse(logicalOr[0].logical_and, rawJson)
   if (logicalOr.length > 1) {
-    for (var i = 1; i < logicalOr.length; i++) {
+    for (let i = 1; i < logicalOr.length; i++) {
       moOutput += ' or '
       moOutput += logicalAndParser.parse(logicalOr[i].logical_and, rawJson)
     }
@@ -13,4 +13,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/logicalFactorObj.js
+++ b/json2mo/logicalFactorObj.js
@@ -1,7 +1,7 @@
 function parse (content, rawJson = false) {
   const util = require('util')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.not != null) {
     moOutput += 'not '
   }
@@ -15,4 +15,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/longClassSpecifier.js
+++ b/json2mo/longClassSpecifier.js
@@ -3,10 +3,10 @@ function parse (content, rawJson = false) {
   const compositionParser = require('./composition')
   const classModificationParser = require('./classModification')
 
-  var identifier = content.identifier
-  var isExtends = content.is_extends
+  const identifier = content.identifier
+  const isExtends = content.is_extends
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (isExtends != null) {
     if (isExtends) {
@@ -27,12 +27,12 @@ function parse (content, rawJson = false) {
   }
 
   if (rawJson) {
-    var stringComment = content.string_comment
+    const stringComment = content.string_comment
     if (stringComment != null) {
       moOutput += util.format('\n%s\n', stringComment)
     }
   } else {
-    var descriptionString = content.description_string
+    const descriptionString = content.description_string
     if (descriptionString != null) {
       moOutput += util.format('\n"%s"\n', descriptionString)
     }
@@ -46,4 +46,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/modification.js
+++ b/json2mo/modification.js
@@ -1,9 +1,9 @@
 function parse (content, rawJson = false) {
   const classModificationParser = require('./classModification')
   const expressionParser = require('./expression')
-  var moOutput = ''
+  let moOutput = ''
 
-  var haveClaMod = content.class_modification != null
+  const haveClaMod = content.class_modification != null
   if (haveClaMod) {
     moOutput += classModificationParser.parse(content.class_modification, rawJson)
   }
@@ -25,4 +25,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/name.js
+++ b/json2mo/name.js
@@ -2,9 +2,9 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const namePartParser = require('./namePart')
 
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
-    var nameParts = content.name_parts
+    const nameParts = content.name_parts
     if (nameParts != null) {
       nameParts.forEach(ele => {
         moOutput += namePartParser.parse(ele, rawJson)
@@ -17,4 +17,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/namePart.js
+++ b/json2mo/namePart.js
@@ -1,5 +1,5 @@
 function parse (content, rawJson = false) {
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     if (content.dot_op != null) {
       if (content.dot_op) {
@@ -14,4 +14,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/namedArgument.js
+++ b/json2mo/namedArgument.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const functionArgumentParser = require('./functionArgument')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.identifier != null) {
     moOutput += util.format('%s=', content.identifier)
   }
@@ -13,4 +13,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/namedArguments.js
+++ b/json2mo/namedArguments.js
@@ -1,7 +1,7 @@
 function parse (content, rawJson = false) {
   const namedArgumentParser = require('./namedArgument')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (rawJson) {
     if (content.named_argument != null) {
@@ -16,4 +16,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/outputExpressionList.js
+++ b/json2mo/outputExpressionList.js
@@ -1,8 +1,8 @@
 function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
 
-  var moOutput = ''
-  var outputExpressions = null
+  let moOutput = ''
+  let outputExpressions = null
   if (rawJson) {
     outputExpressions = content.output_expressions
   } else {
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/shortClassDefinition.js
+++ b/json2mo/shortClassDefinition.js
@@ -2,7 +2,7 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const shortClassSpecifierParser = require('./shortClassSpecifier')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.class_prefixes != null) {
     moOutput += util.format('%s ', content.class_prefixes)
   }
@@ -12,4 +12,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/shortClassSpecifier.js
+++ b/json2mo/shortClassSpecifier.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const shortClassSpecifierValueParser = require('./shortClassSpecifierValue')
 
-  var moOutput = ''
-  var identifier = content.identifier
+  let moOutput = ''
+  const identifier = content.identifier
 
   if (identifier != null) {
     moOutput += util.format('%s=', identifier)
@@ -21,4 +21,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/shortClassSpecifierValue.js
+++ b/json2mo/shortClassSpecifierValue.js
@@ -6,7 +6,7 @@ function parse (content, rawJson = false) {
   const commentParser = require('./comment')
   const enumListParser = require('./enumList')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (content.name == null) {
     moOutput += 'enumeration ('
@@ -41,4 +41,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/simpleExpression.js
+++ b/json2mo/simpleExpression.js
@@ -5,7 +5,7 @@ function parse (content, rawJson = false) {
   const logicalExpressionParser = require('./logicalExpression')
   const ifExpressionParser = require('./ifExpressionObj')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content != null) {
     if (rawJson) {
       moOutput += util.format('%s', JSON.stringify(content))
@@ -26,4 +26,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/statement.js
+++ b/json2mo/statement.js
@@ -8,7 +8,7 @@ function parse (content, rawJson) {
   const whenStatementParser = require('./whenStatement')
   const commentParser = require('./comment')
 
-  var moOutput = ''
+  let moOutput = ''
   if (content.assignment_statement != null) {
     moOutput += '\n'
     moOutput += assignmentStatementParser.parse(content.assignment_statement, rawJson)
@@ -52,4 +52,4 @@ function parse (content, rawJson) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/storedDefiniton.js
+++ b/json2mo/storedDefiniton.js
@@ -2,9 +2,9 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const finalClassDefinitionParser = require('./finalClassDefinition')
 
-  var within = content.within
+  const within = content.within
 
-  var moOutput = ''
+  let moOutput = ''
   if (within != null) {
     moOutput += util.format('within %s;\n', within)
   }
@@ -27,4 +27,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/subscript.js
+++ b/json2mo/subscript.js
@@ -1,7 +1,7 @@
 function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
 
-  var moOutput = ''
+  let moOutput = ''
 
   if (rawJson) {
     moOutput += '['
@@ -15,4 +15,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/typeSpecifier.js
+++ b/json2mo/typeSpecifier.js
@@ -2,17 +2,17 @@ function parse (content, rawJson = false) {
   const util = require('util')
   const nameParser = require('./name')
 
-  var moOutput = ''
+  let moOutput = ''
   if (rawJson) {
     if (content.name != null) {
       moOutput += nameParser.parse(content.name, rawJson)
     }
   } else {
-    var name = content
+    const name = content
     moOutput += util.format('%s ', name)
   }
 
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/whenEquation.js
+++ b/json2mo/whenEquation.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const equationParser = require('./equation')
 
-  var moOutput = ''
-  var whenElsewhens = null
+  let moOutput = ''
+  let whenElsewhens = null
   if (rawJson) {
     whenElsewhens = content.when_elsewhen
   } else {
@@ -17,8 +17,8 @@ function parse (content, rawJson = false) {
         moOutput += expressionParser.parse(ele.condition, rawJson)
       }
       moOutput += '\n'
-      var thenEquations = ele.then
-      var thenOutput = ''
+      const thenEquations = ele.then
+      let thenOutput = ''
       if (thenEquations != null) {
         thenEquations.forEach(thenEqu => {
           thenOutput += equationParser.parse(thenEqu, rawJson)
@@ -37,4 +37,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/whenStatement.js
+++ b/json2mo/whenStatement.js
@@ -2,8 +2,8 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const statementParser = require('./statement')
 
-  var moOutput = ''
-  var whenElsewhens = null
+  let moOutput = ''
+  let whenElsewhens = null
   if (rawJson) {
     whenElsewhens = content.when_elsewhen
   } else {
@@ -17,8 +17,8 @@ function parse (content, rawJson = false) {
         moOutput += expressionParser.parse(ele.condition, rawJson)
       }
       moOutput += '\n'
-      var thenStatements = ele.then
-      var thenOutput = ''
+      const thenStatements = ele.then
+      let thenOutput = ''
       if (thenStatements != null) {
         thenStatements.forEach(thenSta => {
           thenOutput += statementParser.parse(thenSta, rawJson)
@@ -37,4 +37,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/json2mo/whileStatement.js
+++ b/json2mo/whileStatement.js
@@ -2,14 +2,14 @@ function parse (content, rawJson = false) {
   const expressionParser = require('./expression')
   const statementParser = require('./statement')
 
-  var moOutput = ''
+  let moOutput = ''
   moOutput += 'while '
   if (content.condition != null) { // in simplified json
     moOutput += expressionParser.parse(content.condition, rawJson)
   }
   moOutput += 'loop \n'
 
-  var loopStatements = content.loop_statements
+  const loopStatements = content.loop_statements
   loopStatements.forEach(ele => {
     moOutput += statementParser.parse(ele, rawJson)
     moOutput += ';\n'
@@ -18,4 +18,4 @@ function parse (content, rawJson = false) {
   return moOutput
 }
 
-module.exports = {parse}
+module.exports = { parse }

--- a/lib/graphicalPrimitives.js
+++ b/lib/graphicalPrimitives.js
@@ -53,12 +53,12 @@ function graphicAnnotationObj (name, mod) {
  */
 function lineObj (mod) {
   const claModArr = mod.class_modification
-  var names = []
-  var values = []
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  const names = []
+  const values = []
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     names.push(name)
     values.push(expression)
   }
@@ -72,12 +72,12 @@ function lineObj (mod) {
  */
 function textObj (mod) {
   const claModArr = mod.class_modification
-  var names = []
-  var values = []
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  const names = []
+  const values = []
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     names.push(name)
     values.push(expression)
   }
@@ -91,12 +91,12 @@ function textObj (mod) {
  */
 function rectangleObj (mod) {
   const claModArr = mod.class_modification
-  var names = []
-  var values = []
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  const names = []
+  const values = []
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     names.push(name)
     values.push(expression)
   }
@@ -110,12 +110,12 @@ function rectangleObj (mod) {
  */
 function polygonObj (mod) {
   const claModArr = mod.class_modification
-  var names = []
-  var values = []
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  const names = []
+  const values = []
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     names.push(name)
     values.push(expression)
   }
@@ -129,12 +129,12 @@ function polygonObj (mod) {
  */
 function ellipseObj (mod) {
   const claModArr = mod.class_modification
-  var names = []
-  var values = []
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  const names = []
+  const values = []
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     names.push(name)
     values.push(expression)
   }
@@ -148,12 +148,12 @@ function ellipseObj (mod) {
  */
 function bitmapObj (mod) {
   const claModArr = mod.class_modification
-  var names = []
-  var values = []
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  const names = []
+  const values = []
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     names.push(name)
     values.push(expression)
   }
@@ -167,21 +167,21 @@ function bitmapObj (mod) {
  */
 function placementObj (mod) {
   const claModArr = mod.class_modification
-  var visible, iconVisible, transformation, iconTransformation
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var modification = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification'], ithEle)
+  let visible, iconVisible, transformation, iconTransformation
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const modification = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification'], ithEle)
     if (name === 'visible') { visible = modification.expression.simple_expression }
     if (name === 'iconVisible') { iconVisible = modification.expression.simple_expression }
     if (name === 'transformation') { transformation = transformationObj(modification) }
     if (name === 'iconTransformation') { iconTransformation = transformationObj(modification) }
   }
   return Object.assign(
-    {'visible': visible},
-    {'iconVisible': iconVisible},
-    {'transformation': transformation},
-    {'iconTransformation': iconTransformation}
+    { visible },
+    { iconVisible },
+    { transformation },
+    { iconTransformation }
   )
 }
 
@@ -192,19 +192,19 @@ function placementObj (mod) {
  */
 function coordinateSystemObj (mod) {
   const claModArr = mod.class_modification
-  var extent, preserveAspectRatio, initialScale
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  let extent, preserveAspectRatio, initialScale
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     if (name === 'extent') { extent = pointsObj(expression) }
     if (name === 'preserveAspectRatio') { preserveAspectRatio = expression }
     if (name === 'initialScale') { initialScale = Number(expression) }
   }
   return Object.assign(
-    {'extent': extent},
-    {'preserveAspectRatio': preserveAspectRatio},
-    {'initialScale': initialScale}
+    { extent },
+    { preserveAspectRatio },
+    { initialScale }
   )
 }
 
@@ -216,13 +216,13 @@ function coordinateSystemObj (mod) {
 function graphicsObj (mod) {
   const graStr = mod.expression.simple_expression
   const graItes = ['Line', 'Text', 'Rectangle', 'Polygon', 'Ellipse', 'Bitmap']
-  var linLoc, texLoc, recLoc, polLoc, ellLoc, bitLoc
-  var tempLocs = []
-  var allLocs
+  let linLoc, texLoc, recLoc, polLoc, ellLoc, bitLoc
+  const tempLocs = []
+  // const allLocs = []
   // find the location of each primitive
-  for (var i = 0; i < graItes.length; i++) {
-    var ithEle = graItes[i]
-    var seaKey = ithEle + '('
+  for (let i = 0; i < graItes.length; i++) {
+    const ithEle = graItes[i]
+    const seaKey = ithEle + '('
     if (ithEle === 'Line') { linLoc = locations(seaKey, graStr) }
     if (ithEle === 'Text') { texLoc = locations(seaKey, graStr) }
     if (ithEle === 'Rectangle') { recLoc = locations(seaKey, graStr) }
@@ -230,24 +230,24 @@ function graphicsObj (mod) {
     if (ithEle === 'Ellipse') { ellLoc = locations(seaKey, graStr) }
     if (ithEle === 'Bitmap') { bitLoc = locations(seaKey, graStr) }
   }
-  allLocs = tempLocs.concat(linLoc || [])
-                    .concat(texLoc || [])
-                    .concat(recLoc || [])
-                    .concat(polLoc || [])
-                    .concat(ellLoc || [])
-                    .concat(bitLoc || [])
-                    .sort(function (a, b) { return (a - b) })
-  var graArr = []
-  var firstBra, lastBra, name, attStr
+  const allLocs = tempLocs.concat(linLoc || [])
+    .concat(texLoc || [])
+    .concat(recLoc || [])
+    .concat(polLoc || [])
+    .concat(ellLoc || [])
+    .concat(bitLoc || [])
+    .sort(function (a, b) { return (a - b) })
+  const graArr = []
+  let firstBra, lastBra, name, attStr
   if (allLocs.length > 1) {
-    for (var j = 0; j < allLocs.length - 1; j++) {
+    for (let j = 0; j < allLocs.length - 1; j++) {
       firstBra = graStr.indexOf('(', allLocs[j])
       lastBra = graStr.lastIndexOf(')', allLocs[j + 1])
       name = graStr.substring(allLocs[j], firstBra)
       attStr = graStr.substring(firstBra + 1, lastBra)
       graArr.push(Object.assign(
-        {'name': name},
-        {'attribute': graphicAttributeObj(name, attStr)}
+        { name },
+        { attribute: graphicAttributeObj(name, attStr) }
       ))
     }
   }
@@ -256,8 +256,8 @@ function graphicsObj (mod) {
   name = graStr.substring(allLocs[allLocs.length - 1], firstBra)
   attStr = graStr.substring(firstBra + 1, lastBra)
   graArr.push(Object.assign(
-    {'name': name},
-    {'attribute': graphicAttributeObj(name, attStr)}
+    { name },
+    { attribute: graphicAttributeObj(name, attStr) }
   ))
   return graArr
 }
@@ -269,19 +269,19 @@ function graphicsObj (mod) {
  */
 function transformationObj (mod) {
   const claModArr = mod.class_modification
-  var origin, extent, rotation
-  for (var i = 0; i < claModArr.length; i++) {
-    var ithEle = claModArr[i]
-    var name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
-    var expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
+  let origin, extent, rotation
+  for (let i = 0; i < claModArr.length; i++) {
+    const ithEle = claModArr[i]
+    const name = getProperty(['element_modification_or_replaceable', 'element_modification', 'name'], ithEle)
+    const expression = getProperty(['element_modification_or_replaceable', 'element_modification', 'modification', 'expression', 'simple_expression'], ithEle)
     if (name === 'extent') { extent = pointsObj(expression) }
     if (name === 'origin') { origin = originObj(expression) }
     if (name === 'rotation') { rotation = Number(expression) }
   }
   return Object.assign(
-    {'origin': origin},
-    {'extent': extent},
-    {'rotation': rotation}
+    { origin },
+    { extent },
+    { rotation }
   )
 }
 
@@ -293,18 +293,18 @@ function transformationObj (mod) {
 function graphicItemsObj (graIteObj) {
   const names = graIteObj.names
   const expressions = graIteObj.expressions
-  var visible, origin, rotation
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = expressions[i]
+  let visible, origin, rotation
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = expressions[i]
     if (name === 'visible') { visible = expression }
     if (name === 'origin') { origin = originObj(expression) }
     if (name === 'rotation') { rotation = Number(expression) }
   }
   return Object.assign(
-    {'visible': visible},
-    {'origin': origin},
-    {'rotation': rotation}
+    { visible },
+    { origin },
+    { rotation }
   )
 }
 
@@ -317,8 +317,8 @@ function originObj (expStr) {
   const subStr = expStr.substring(expStr.indexOf('{') + 1, expStr.lastIndexOf('}'))
   const subStrArr = subStr.split(',')
   return Object.assign(
-    {'x': Number(subStrArr[0])},
-    {'y': Number(subStrArr[1])}
+    { x: Number(subStrArr[0]) },
+    { y: Number(subStrArr[1]) }
   )
 }
 
@@ -330,10 +330,10 @@ function originObj (expStr) {
 function filledShapeObj (filShaObj) {
   const names = filShaObj.names
   const expressions = filShaObj.expressions
-  var lineColor, fillColor, pattern, fillPattern, lineThickness
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = expressions[i]
+  let lineColor, fillColor, pattern, fillPattern, lineThickness
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = expressions[i]
     if (name === 'lineColor') { lineColor = colorObj(expression) }
     if (name === 'fillColor') { fillColor = colorObj(expression) }
     if (name === 'pattern') { pattern = expression }
@@ -341,29 +341,29 @@ function filledShapeObj (filShaObj) {
     if (name === 'lineThickness') { lineThickness = Number(expression) }
   }
   return Object.assign(
-    {'lineColor': lineColor},
-    {'fillColor': fillColor},
-    {'pattern': pattern},
-    {'fillPattern': fillPattern},
-    {'lineThickness': lineThickness}
+    { lineColor },
+    { fillColor },
+    { pattern },
+    { fillPattern },
+    { lineThickness }
   )
 }
 
 function graIteFilShaObjs (graIteNams, graIteExps, filShaNams, filShaExps) {
-  var graIteObjs, filShaObjs
+  let graIteObjs, filShaObjs
   if (graIteNams && graIteNams.length > 0) {
     graIteObjs = graphicItemsObj(Object.assign(
-      {'names': graIteNams}, {'expressions': graIteExps}
+      { names: graIteNams }, { expressions: graIteExps }
     ))
   }
   if (filShaNams && filShaNams.length > 0) {
     filShaObjs = filledShapeObj(Object.assign(
-      {'names': filShaNams}, {'expressions': filShaExps}
+      { names: filShaNams }, { expressions: filShaExps }
     ))
   }
   return Object.assign(
-    {'graIteObjs': graIteObjs},
-    {'filShaObjs': filShaObjs}
+    { graIteObjs },
+    { filShaObjs }
   )
 }
 
@@ -376,12 +376,12 @@ function pointsObj (expStr) {
   const subStr = expStr.substring(expStr.indexOf('{') + 1, expStr.lastIndexOf('}'))
   const lefBraLocs = locations('{', subStr)
   const rigBraLocs = locations('}', subStr)
-  var eleStr, eleStrArr
+  let eleStr, eleStrArr
   const points = []
-  for (var i = 0; i < lefBraLocs.length; i++) {
+  for (let i = 0; i < lefBraLocs.length; i++) {
     eleStr = subStr.substring(lefBraLocs[i] + 1, rigBraLocs[i])
     eleStrArr = eleStr.split(',')
-    points.push(Object.assign({'x': Number(eleStrArr[0]), 'y': Number(eleStrArr[1])}))
+    points.push(Object.assign({ x: Number(eleStrArr[0]), y: Number(eleStrArr[1]) }))
   }
   return points
 }
@@ -395,9 +395,9 @@ function colorObj (expStr) {
   const subStr = expStr.substring(expStr.indexOf('{') + 1, expStr.lastIndexOf('}'))
   const subStrArr = subStr.split(',')
   return Object.assign(
-    {'r': Number(subStrArr[0])},
-    {'g': Number(subStrArr[1])},
-    {'b': Number(subStrArr[2])}
+    { r: Number(subStrArr[0]) },
+    { g: Number(subStrArr[1]) },
+    { b: Number(subStrArr[2]) }
   )
 }
 
@@ -419,9 +419,9 @@ function graphicAttributeObj (keyNam, valStr) {
  * @param valStr string
  */
 function lineAttributeObj (valStr) {
-  var nameVales = nameAttributePair(valStr)
-  var names = nameVales.names
-  var values = nameVales.values
+  const nameVales = nameAttributePair(valStr)
+  const names = nameVales.names
+  const values = nameVales.values
   return lineAttribute(names, values)
 }
 
@@ -431,9 +431,9 @@ function lineAttributeObj (valStr) {
  * @param valStr string
  */
 function textAttributeObj (valStr) {
-  var nameVales = nameAttributePair(valStr)
-  var names = nameVales.names
-  var values = nameVales.values
+  const nameVales = nameAttributePair(valStr)
+  const names = nameVales.names
+  const values = nameVales.values
   return textAttribute(names, values)
 }
 
@@ -443,9 +443,9 @@ function textAttributeObj (valStr) {
  * @param valStr string
  */
 function rectangleAttributeObj (valStr) {
-  var nameVales = nameAttributePair(valStr)
-  var names = nameVales.names
-  var values = nameVales.values
+  const nameVales = nameAttributePair(valStr)
+  const names = nameVales.names
+  const values = nameVales.values
   return rectangleAttribute(names, values)
 }
 
@@ -455,9 +455,9 @@ function rectangleAttributeObj (valStr) {
  * @param valStr string
  */
 function polygonAttributeObj (valStr) {
-  var nameVales = nameAttributePair(valStr)
-  var names = nameVales.names
-  var values = nameVales.values
+  const nameVales = nameAttributePair(valStr)
+  const names = nameVales.names
+  const values = nameVales.values
   return polygonAttribute(names, values)
 }
 
@@ -467,9 +467,9 @@ function polygonAttributeObj (valStr) {
  * @param valStr string
  */
 function ellipseAttributeObj (valStr) {
-  var nameVales = nameAttributePair(valStr)
-  var names = nameVales.names
-  var values = nameVales.values
+  const nameVales = nameAttributePair(valStr)
+  const names = nameVales.names
+  const values = nameVales.values
   return ellipseAttribute(names, values)
 }
 
@@ -479,9 +479,9 @@ function ellipseAttributeObj (valStr) {
  * @param valStr string
  */
 function bitmapAttributeObj (valStr) {
-  var nameVales = nameAttributePair(valStr)
-  var names = nameVales.names
-  var values = nameVales.values
+  const nameVales = nameAttributePair(valStr)
+  const names = nameVales.names
+  const values = nameVales.values
   return bitmapAttribute(names, values)
 }
 
@@ -492,10 +492,10 @@ function bitmapAttributeObj (valStr) {
  * @param values value string array
  */
 function lineAttribute (names, values) {
-  var points, color, pattern, thickness, arrowSize, smooth, visible
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = values[i]
+  let points, color, pattern, thickness, arrowSize, smooth, visible
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = values[i]
     if (name === 'pattern') { pattern = expression }
     if (name === 'thickness') { thickness = Number(expression) }
     if (name === 'arrowSize') { arrowSize = Number(expression) }
@@ -507,13 +507,13 @@ function lineAttribute (names, values) {
     if (name === 'color') { color = colorObj(expression) }
   }
   return Object.assign(
-    {'points': points},
-    {'color': color},
-    {'pattern': pattern},
-    {'thickness': thickness},
-    {'arrowSize': arrowSize},
-    {'smooth': smooth},
-    {'visible': visible}
+    { points },
+    { color },
+    { pattern },
+    { thickness },
+    { arrowSize },
+    { smooth },
+    { visible }
   )
 }
 
@@ -526,15 +526,15 @@ function lineAttribute (names, values) {
 function textAttribute (names, values) {
   const graItes = ['visible', 'origin', 'rotation']
   const filledShape = ['lineColor', 'fillColor', 'pattern', 'fillPattern', 'lineThickness']
-  var graIteNams = []
-  var graIteExps = []
-  var filShaNams = []
-  var filShaExps = []
-  var extent, textString, fontSize, fontName, textColor
-  var horizontalAlignment, string, index
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = values[i]
+  const graIteNams = []
+  const graIteExps = []
+  const filShaNams = []
+  const filShaExps = []
+  let extent, textString, fontSize, fontName, textColor
+  let horizontalAlignment, string, index
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = values[i]
     if (name === 'extent') { extent = pointsObj(expression) }
     if (name === 'textString') { textString = expression }
     if (name === 'fontSize') { fontSize = Number(expression) }
@@ -554,16 +554,16 @@ function textAttribute (names, values) {
       filShaExps.push(expression)
     }
   }
-  var graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
+  const graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
   return Object.assign(
-    {'extent': extent},
-    {'textString': textString},
-    {'fontSize': fontSize},
-    {'fontName': fontName},
-    {'textColor': textColor},
-    {'horizontalAlignment': horizontalAlignment},
-    {'string': string},
-    {'index': index},
+    { extent },
+    { textString },
+    { fontSize },
+    { fontName },
+    { textColor },
+    { horizontalAlignment },
+    { string },
+    { index },
     graIteFilShaObj ? graIteFilShaObj.graIteObjs : undefined,
     graIteFilShaObj ? graIteFilShaObj.filShaObjs : undefined
   )
@@ -578,14 +578,14 @@ function textAttribute (names, values) {
 function rectangleAttribute (names, values) {
   const graItes = ['visible', 'origin', 'rotation']
   const filledShape = ['lineColor', 'fillColor', 'pattern', 'fillPattern', 'lineThickness']
-  var graIteNams = []
-  var graIteExps = []
-  var filShaNams = []
-  var filShaExps = []
-  var extent, radius, borderPattern
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = values[i]
+  const graIteNams = []
+  const graIteExps = []
+  const filShaNams = []
+  const filShaExps = []
+  let extent, radius, borderPattern
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = values[i]
     if (name === 'extent') { extent = pointsObj(expression) }
     if (name === 'radius') { radius = Number(expression) }
     if (name === 'borderPattern') { borderPattern = expression }
@@ -600,11 +600,11 @@ function rectangleAttribute (names, values) {
       filShaExps.push(expression)
     }
   }
-  var graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
+  const graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
   return Object.assign(
-    {'extent': extent},
-    {'radius': radius},
-    {'borderPattern': borderPattern},
+    { extent },
+    { radius },
+    { borderPattern },
     graIteFilShaObj ? graIteFilShaObj.graIteObjs : undefined,
     graIteFilShaObj ? graIteFilShaObj.filShaObjs : undefined
   )
@@ -619,14 +619,14 @@ function rectangleAttribute (names, values) {
 function polygonAttribute (names, values) {
   const graItes = ['visible', 'origin', 'rotation']
   const filledShape = ['lineColor', 'fillColor', 'pattern', 'fillPattern', 'lineThickness']
-  var graIteNams = []
-  var graIteExps = []
-  var filShaNams = []
-  var filShaExps = []
-  var points, smooth
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = values[i]
+  const graIteNams = []
+  const graIteExps = []
+  const filShaNams = []
+  const filShaExps = []
+  let points, smooth
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = values[i]
     if (name === 'points') { points = pointsObj(expression) }
     if (name === 'smooth') { smooth = expression }
     // Check if it is the graphicItems
@@ -640,10 +640,10 @@ function polygonAttribute (names, values) {
       filShaExps.push(expression)
     }
   }
-  var graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
+  const graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
   return Object.assign(
-    {'points': points},
-    {'smooth': smooth},
+    { points },
+    { smooth },
     graIteFilShaObj ? graIteFilShaObj.graIteObjs : undefined,
     graIteFilShaObj ? graIteFilShaObj.filShaObjs : undefined
   )
@@ -658,14 +658,14 @@ function polygonAttribute (names, values) {
 function ellipseAttribute (names, values) {
   const graItes = ['visible', 'origin', 'rotation']
   const filledShape = ['lineColor', 'fillColor', 'pattern', 'fillPattern', 'lineThickness']
-  var graIteNams = []
-  var graIteExps = []
-  var filShaNams = []
-  var filShaExps = []
-  var extent, startAngle, endAngle, closure
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = values[i]
+  const graIteNams = []
+  const graIteExps = []
+  const filShaNams = []
+  const filShaExps = []
+  let extent, startAngle, endAngle, closure
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = values[i]
     if (name === 'extent') { extent = pointsObj(expression) }
     if (name === 'startAngle') { startAngle = Number(expression) }
     if (name === 'endAngle') { endAngle = Number(expression) }
@@ -681,12 +681,12 @@ function ellipseAttribute (names, values) {
       filShaExps.push(expression)
     }
   }
-  var graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
+  const graIteFilShaObj = graIteFilShaObjs(graIteNams, graIteExps, filShaNams, filShaExps)
   return Object.assign(
-    {'extent': extent},
-    {'startAngle': startAngle},
-    {'endAngle': endAngle},
-    {'closure': closure},
+    { extent },
+    { startAngle },
+    { endAngle },
+    { closure },
     graIteFilShaObj ? graIteFilShaObj.graIteObjs : undefined,
     graIteFilShaObj ? graIteFilShaObj.filShaObjs : undefined
   )
@@ -700,12 +700,12 @@ function ellipseAttribute (names, values) {
  */
 function bitmapAttribute (names, values) {
   const graItes = ['visible', 'origin', 'rotation']
-  var graIteNams = []
-  var graIteExps = []
-  var extent, fileName, imageSource
-  for (var i = 0; i < names.length; i++) {
-    var name = names[i]
-    var expression = values[i]
+  const graIteNams = []
+  const graIteExps = []
+  let extent, fileName, imageSource
+  for (let i = 0; i < names.length; i++) {
+    const name = names[i]
+    const expression = values[i]
     if (name === 'extent') { extent = pointsObj(expression) }
     if (name === 'fileName') { fileName = expression }
     if (name === 'imageSource') { imageSource = expression }
@@ -715,11 +715,11 @@ function bitmapAttribute (names, values) {
       graIteExps.push(expression)
     }
   }
-  var graIteObj = graIteFilShaObjs(graIteNams, graIteExps)
+  const graIteObj = graIteFilShaObjs(graIteNams, graIteExps)
   return Object.assign(
-    {'extent': extent},
-    {'fileName': fileName},
-    {'imageSource': imageSource},
+    { extent },
+    { fileName },
+    { imageSource },
     graIteObj ? graIteObj.graIteObjs : undefined
   )
 }
@@ -731,26 +731,26 @@ function bitmapAttribute (names, values) {
  */
 function nameAttributePair (valStr) {
   // search for '=' locations
-  var equLocs = locations('=', valStr)
+  const equLocs = locations('=', valStr)
   // search for ',' locations
-  var comLocs = []
-  for (var i = 0; i < equLocs.length; i++) {
-    var comLoc = valStr.lastIndexOf(',', equLocs[i])
+  const comLocs = []
+  for (let i = 0; i < equLocs.length; i++) {
+    const comLoc = valStr.lastIndexOf(',', equLocs[i])
     if (comLoc > -1) { comLocs.push(comLoc) }
   }
-  var keyNam = []
-  var val = []
+  const keyNam = []
+  const val = []
   keyNam.push(valStr.substring(0, equLocs[0]))
   if (comLocs.length > 0) {
-    for (var j = 0; j < comLocs.length; j++) {
+    for (let j = 0; j < comLocs.length; j++) {
       keyNam.push(valStr.substring(comLocs[j] + 1, equLocs[j + 1]))
       val.push(valStr.substring(equLocs[j] + 1, comLocs[j]))
     }
   }
   val.push(valStr.substring(equLocs[equLocs.length - 1] + 1))
   return Object.assign(
-    {'names': keyNam},
-    {'values': val}
+    { names: keyNam },
+    { values: val }
   )
 }
 
@@ -761,8 +761,8 @@ function nameAttributePair (valStr) {
  * @param str string
  */
 function locations (substr, str) {
-  var a = []
-  var i = -1
+  const a = []
+  let i = -1
   while ((i = str.indexOf(substr, i + 1)) >= 0) { a.push(i) }
   return a
 }

--- a/lib/jsonquery.js
+++ b/lib/jsonquery.js
@@ -1173,9 +1173,9 @@ function simpleExpression (simExp, outStr = false) {
   if ((funCal || forLoo || logExp || ifExp) && !outStr) {
     if (logExp) {
       var logical_or = logExp.logical_or
-      if (logical_or.length == 1 && logical_or[0].logical_and.length == 1
-          && logical_or[0].logical_and[0].arithmetic_expressions.length == 1
-          && !logical_or[0].logical_and[0].not) {
+      if (logical_or.length == 1 && logical_or[0].logical_and.length == 1 &&
+          logical_or[0].logical_and[0].arithmetic_expressions.length == 1 &&
+          !logical_or[0].logical_and[0].not) {
         return logical_or[0].logical_and[0].arithmetic_expressions[0].name
       } else {
         return Object.assign({'logical_expression': logExp})
@@ -1288,7 +1288,7 @@ function logicalFactorObj (fac) {
   return Object.assign(
     {'not': notOpe || undefined},
     {'arithmetic_expressions': ariExpArray},
-    {'relation_operator': relOp ? relOp : undefined}
+    {'relation_operator': relOp || undefined}
   )
 }
 

--- a/lib/jsonquery.js
+++ b/lib/jsonquery.js
@@ -1,5 +1,6 @@
 const ut = require('../lib/util.js')
 const graPri = require('../lib/graphicalPrimitives.js')
+const { is } = require('bluebird')
 
 /**
  * Get the JSON property `p` from the json data `o`
@@ -297,7 +298,7 @@ function expression (expObj) {
   const ifExp = expObj.if_expression
   const ifExpObj = ifExp ? this.ifExpression(ifExp) : undefined
   return Object.assign(
-    {'simple_expression': simExp ? this.simpleExpression(simExp) : undefined},
+    {'simple_expression': simExp ? this.simpleExpression(simExp, false) : undefined},
     {'if_expression': !ut.isEmptyObject(ifExpObj) ? ifExpObj : undefined}
   )
 }
@@ -1149,6 +1150,7 @@ function derClassSpecifier (derClaSpe) {
  * Get the string of simple expression
  *
  * @param simExp simple expression object
+ * @param outStr flag to indicate if it should output string
  */
 function simpleExpression (simExp, outStr = false) {
   const logExp1 = this.logicalExpression(simExp.logical_expression1)
@@ -1169,12 +1171,22 @@ function simpleExpression (simExp, outStr = false) {
     logExp = this.logicalExpressionObj(simExp.logical_expression1)
   }
   if ((funCal || forLoo || logExp || ifExp) && !outStr) {
-    return Object.assign(
-      {'function_call': funCal},
-      {'for_loop': forLoo},
-      {'logical_expression': logExp},
-      {'if_expression': ifExp}
-    )
+    if (logExp) {
+      var logical_or = logExp.logical_or
+      if (logical_or.length == 1 && logical_or[0].logical_and.length == 1
+          && logical_or[0].logical_and[0].arithmetic_expressions.length == 1
+          && !logical_or[0].logical_and[0].not) {
+        return logical_or[0].logical_and[0].arithmetic_expressions[0].name
+      } else {
+        return Object.assign({'logical_expression': logExp})
+      }
+    } else {
+      return Object.assign(
+        {'function_call': funCal},
+        {'for_loop': forLoo},
+        {'if_expression': ifExp}
+      )
+    }
   } else {
     return (logExp1 + logExp2 + logExp3)
   }
@@ -1267,15 +1279,16 @@ function logicalFactorObj (fac) {
   const rel = fac.relation
   const relOp = rel.rel_op
   const ariExp1 = this.arithmeticExpression(rel.arithmetic_expression1)
-  if (!relOp) { return undefined }
-  const ariExp2 = this.arithmeticExpression(rel.arithmetic_expression2)
   const ariExpArray = []
   ariExpArray.push(Object.assign({'name': ariExp1}))
-  ariExpArray.push(Object.assign({'name': ariExp2}))
+  if (relOp) {
+    const ariExp2 = this.arithmeticExpression(rel.arithmetic_expression2)
+    ariExpArray.push(Object.assign({'name': ariExp2}))
+  }
   return Object.assign(
     {'not': notOpe || undefined},
     {'arithmetic_expressions': ariExpArray},
-    {'relation_operator': relOp}
+    {'relation_operator': relOp ? relOp : undefined}
   )
 }
 
@@ -1785,7 +1798,7 @@ function forIndString (forInd) {
 function expressionString (exp, outStr = false) {
   const simExp = exp.simple_expression
   const ifExp = exp.if_expression
-  return simExp ? this.simpleExpression(simExp, outStr) : this.ifExpString(ifExp)
+  return simExp ? this.simpleExpression(simExp, true) : this.ifExpString(ifExp)
 }
 
 /**

--- a/lib/jsonquery.js
+++ b/lib/jsonquery.js
@@ -1,6 +1,6 @@
 const ut = require('../lib/util.js')
 const graPri = require('../lib/graphicalPrimitives.js')
-const { is } = require('bluebird')
+// const { is } = require('bluebird')
 
 /**
  * Get the JSON property `p` from the json data `o`
@@ -20,18 +20,18 @@ function simplifyModelicaJSON (model, parseMode) {
   const within = model.within
   const finalDef = model.final_class_definitions
   const claDefArr = []
-  for (var i = 0; i < finalDef.length; i++) {
-    var obj = finalDef[i]
+  for (let i = 0; i < finalDef.length; i++) {
+    const obj = finalDef[i]
     const final = obj.is_final ? true : undefined
     const claDef = this.classDefinition(obj.class_definition)
-    claDefArr.push(Object.assign({'final': final}, claDef))
+    claDefArr.push(Object.assign({ final }, claDef))
   }
   return Object.assign(
-    {'within': within},
-    {'class_definition': claDefArr},
-    {'modelicaFile': model.modelicaFile},
-    {'fullMoFilePath': model.fullMoFilePath},
-    {'checksum': model.checksum})
+    { within },
+    { class_definition: claDefArr },
+    { modelicaFile: model.modelicaFile },
+    { fullMoFilePath: model.fullMoFilePath },
+    { checksum: model.checksum })
 }
 
 function classDefinition (claDef) {
@@ -39,9 +39,9 @@ function classDefinition (claDef) {
   const classPrefixes = claDef.class_prefixes
   const classSpecifierObj = this.classSpecifier(claDef.class_specifier)
   return Object.assign(
-    {'encapsulated': encapsulated || undefined},
-    {'class_prefixes': classPrefixes},
-    {'class_specifier': classSpecifierObj}
+    { encapsulated: encapsulated || undefined },
+    { class_prefixes: classPrefixes },
+    { class_specifier: classSpecifierObj }
   )
 }
 
@@ -55,9 +55,11 @@ function classSpecifier (claSpe) {
   const shortClass = claSpe.short_class_specifier
   const derClass = claSpe.der_class_specifier
   if (longClass || shortClass || derClass) {
-    return longClass ? (Object.assign({'long_class_specifier': this.longClassSpecifier(longClass)}))
-    : (shortClass ? (Object.assign({'short_class_specifier': this.shortClassSpecifier(shortClass)}))
-                  : (Object.assign({'der_class_specifier': this.derClassSpecifier(derClass)})))
+    return longClass
+      ? (Object.assign({ long_class_specifier: this.longClassSpecifier(longClass) }))
+      : (shortClass
+          ? (Object.assign({ short_class_specifier: this.shortClassSpecifier(shortClass) }))
+          : (Object.assign({ der_class_specifier: this.derClassSpecifier(derClass) })))
   }
   throw new Error('one of long_class_specifier or short_class_specifier or der_class_specifier must be present in class_specifier')
 }
@@ -68,14 +70,14 @@ function classSpecifier (claSpe) {
  * @param lonClaSpe long_class_specifier value
  */
 function longClassSpecifier (lonClaSpe) {
-  var ident = null
+  let ident = null
   if (lonClaSpe.identifier) {
     ident = lonClaSpe.identifier
   } else {
     throw new Error('missing identifier')
   }
   const desStr = trimDesString(lonClaSpe.string_comment)
-  var comp = null
+  let comp = null
   if (lonClaSpe.composition) {
     comp = this.composition(lonClaSpe.composition)
   } else {
@@ -85,11 +87,11 @@ function longClassSpecifier (lonClaSpe) {
   const claMod = lonClaSpe.class_modification
   const claModObj = claMod ? this.classModification(claMod) : undefined
   return Object.assign(
-    {'identifier': ident},
-    {'description_string': desStr},
-    {'composition': !ut.isEmptyObject(comp) ? comp : undefined},
-    {'extends': ext || undefined},
-    {'class_modification': claModObj})
+    { identifier: ident },
+    { description_string: desStr },
+    { composition: !ut.isEmptyObject(comp) ? comp : undefined },
+    { extends: ext || undefined },
+    { class_modification: claModObj })
 }
 
 /**
@@ -110,10 +112,10 @@ function composition (com) {
   const ann = com.annotation ? com.annotation.class_modification : null
   const annObj = ann ? this.classModification(ann) : undefined
   return Object.assign(
-    {'element_list': eleLis},
-    {'element_sections': eleSec},
-    {'external_composition': extComObj},
-    {'annotation': (annObj === '()') ? undefined : annObj})
+    { element_list: eleLis },
+    { element_sections: eleSec },
+    { external_composition: extComObj },
+    { annotation: (annObj === '()') ? undefined : annObj })
 }
 
 /**
@@ -124,7 +126,7 @@ function composition (com) {
 function elementList (eleLis) {
   const ele = eleLis.elements
   const eleArr = []
-  for (var i = 0; i < ele.length; i++) {
+  for (let i = 0; i < ele.length; i++) {
     const obj = ele[i]
     const impCla = obj.import_clause
     const extCla = obj.extends_clause
@@ -142,17 +144,17 @@ function elementList (eleLis) {
     const des = obj.comment
     const desObj = des ? this.description(des) : undefined
     eleArr.push(Object.assign(
-      {'import_clause': impCla ? this.importClause(impCla) : undefined},
-      {'extends_clause': extCla ? this.extendsClause(extCla) : undefined},
-      {'redeclare': redeclare || undefined},
-      {'final': final || undefined},
-      {'inner': inner || undefined},
-      {'outer': outer || undefined},
-      {'replaceable': replaceable || undefined},
-      {'constraining_clause': conCla ? this.constrainingClause(conCla) : undefined},
-      {'class_definition': claDef ? this.classDefinition(claDef) : undefined},
-      {'component_clause': comCla ? this.componentClause(comCla) : undefined},
-      {'description': !ut.isEmptyObject(desObj) ? desObj : undefined}))
+      { import_clause: impCla ? this.importClause(impCla) : undefined },
+      { extends_clause: extCla ? this.extendsClause(extCla) : undefined },
+      { redeclare: redeclare || undefined },
+      { final: final || undefined },
+      { inner: inner || undefined },
+      { outer: outer || undefined },
+      { replaceable: replaceable || undefined },
+      { constraining_clause: conCla ? this.constrainingClause(conCla) : undefined },
+      { class_definition: claDef ? this.classDefinition(claDef) : undefined },
+      { component_clause: comCla ? this.componentClause(comCla) : undefined },
+      { description: !ut.isEmptyObject(desObj) ? desObj : undefined }))
   }
   return eleArr
 }
@@ -170,11 +172,11 @@ function importClause (impCla) {
   const comment = impCla.comment
   const desObj = comment ? this.description(comment) : undefined
   return Object.assign(
-    {'identifier': identifier},
-    {'name': name ? this.nameString(name) : undefined},
-    {'dot_star': dotSta ? '.*' : undefined},
-    {'import_list': impLis ? this.importList(impLis) : undefined},
-    {'description': !ut.isEmptyObject(desObj) ? desObj : undefined}
+    { identifier },
+    { name: name ? this.nameString(name) : undefined },
+    { dot_star: dotSta ? '.*' : undefined },
+    { import_list: impLis ? this.importList(impLis) : undefined },
+    { description: !ut.isEmptyObject(desObj) ? desObj : undefined }
   )
 }
 
@@ -198,8 +200,8 @@ function description (des) {
   const ann = des.annotation ? des.annotation.class_modification : null
   const annotation = ann ? this.classModification(ann) : undefined
   return Object.assign(
-    {'description_string': strDes},
-    {'annotation': (annotation === '()') ? undefined : annotation}
+    { description_string: strDes },
+    { annotation: (annotation === '()') ? undefined : annotation }
   )
 }
 
@@ -226,9 +228,9 @@ function extendsClause (extCla) {
   const ann = extCla.annotation ? extCla.annotation.class_modification : null
   const annotation = ann ? this.classModification(ann) : undefined
   return Object.assign(
-    {'name': name ? this.nameString(name) : undefined},
-    {'class_modification': claMod ? this.classModification(claMod) : undefined},
-    {'annotation': (annotation === '()') ? undefined : annotation}
+    { name: name ? this.nameString(name) : undefined },
+    { class_modification: claMod ? this.classModification(claMod) : undefined },
+    { annotation: (annotation === '()') ? undefined : annotation }
   )
 }
 
@@ -241,8 +243,8 @@ function constrainingClause (conCla) {
   const name = conCla.name
   const claMod = conCla.class_modification
   return Object.assign(
-    {'name': name ? this.nameString(name) : undefined},
-    {'class_modification': claMod ? this.classModification(claMod) : undefined}
+    { name: name ? this.nameString(name) : undefined },
+    { class_modification: claMod ? this.classModification(claMod) : undefined }
   )
 }
 
@@ -257,10 +259,10 @@ function componentClause (comCla) {
   const arrSub = comCla.array_subscripts
   const comLis = comCla.component_list
   return Object.assign(
-    {'type_prefix': prefix},
-    {'type_specifier': this.typeSpecifier(typSpe)},
-    {'array_subscripts': arrSub ? this.arraySubscripts(arrSub) : undefined},
-    {'component_list': comLis ? this.componentList(comLis) : undefined}
+    { type_prefix: prefix },
+    { type_specifier: this.typeSpecifier(typSpe) },
+    { array_subscripts: arrSub ? this.arraySubscripts(arrSub) : undefined },
+    { component_list: comLis ? this.componentList(comLis) : undefined }
   )
 }
 
@@ -276,13 +278,13 @@ function typeSpecifier (typSpe) {
  */
 function arraySubscripts (arrSub) {
   const eleArr = []
-  for (var i = 0; i < arrSub.length; i++) {
-    var obj = arrSub[i]
+  for (let i = 0; i < arrSub.length; i++) {
+    const obj = arrSub[i]
     const exp = obj.expression
     const colOp = obj.colon_op
     eleArr.push(Object.assign(
-      {'colon_op': colOp || undefined},
-      {'expression': exp ? this.expression(exp) : undefined}
+      { colon_op: colOp || undefined },
+      { expression: exp ? this.expression(exp) : undefined }
     ))
   }
   return eleArr
@@ -298,8 +300,8 @@ function expression (expObj) {
   const ifExp = expObj.if_expression
   const ifExpObj = ifExp ? this.ifExpression(ifExp) : undefined
   return Object.assign(
-    {'simple_expression': simExp ? this.simpleExpression(simExp, false) : undefined},
-    {'if_expression': !ut.isEmptyObject(ifExpObj) ? ifExpObj : undefined}
+    { simple_expression: simExp ? this.simpleExpression(simExp, false) : undefined },
+    { if_expression: !ut.isEmptyObject(ifExpObj) ? ifExpObj : undefined }
   )
 }
 
@@ -312,18 +314,18 @@ function ifExpression (ifExp) {
   const ifEls = ifExp.if_elseif
   const elsExp = ifExp.else_expression
   const ifElsArr = []
-  for (var i = 0; i < ifEls.length; i++) {
-    var obj = ifEls[i]
+  for (let i = 0; i < ifEls.length; i++) {
+    const obj = ifEls[i]
     const con = obj.condition
     const then = obj.then
     ifElsArr.push(Object.assign(
-      {'condition': con ? this.expression(con) : undefined},
-      {'then': then ? this.expression(then) : undefined}
+      { condition: con ? this.expression(con) : undefined },
+      { then: then ? this.expression(then) : undefined }
     ))
   }
   return Object.assign(
-    {'if_elseif': (ifElsArr.length > 0) ? ifElsArr : undefined},
-    {'else_expression': elsExp ? this.expression(elsExp) : undefined}
+    { if_elseif: (ifElsArr.length > 0) ? ifElsArr : undefined },
+    { else_expression: elsExp ? this.expression(elsExp) : undefined }
   )
 }
 
@@ -335,16 +337,16 @@ function ifExpression (ifExp) {
 function componentList (comLis) {
   const compList = comLis.component_declaration_list
   const decLisArr = []
-  for (var i = 0; i < compList.length; i++) {
-    var obj = compList[i]
+  for (let i = 0; i < compList.length; i++) {
+    const obj = compList[i]
     const dec = obj.declaration
     const conAtt = obj.condition_attribute
     const com = obj.comment
     const comObj = com ? this.description(com) : undefined
     decLisArr.push(Object.assign(
-      {'declaration': dec ? this.declaration(dec) : undefined},
-      {'condition_attribute': conAtt ? {'expression': this.expression(conAtt.expression)} : undefined},
-      {'description': !ut.isEmptyObject(comObj) ? comObj : undefined}
+      { declaration: dec ? this.declaration(dec) : undefined },
+      { condition_attribute: conAtt ? { expression: this.expression(conAtt.expression) } : undefined },
+      { description: !ut.isEmptyObject(comObj) ? comObj : undefined }
     ))
   }
   return decLisArr
@@ -360,9 +362,9 @@ function declaration (dec) {
   const arrSub = dec.array_subscripts
   const mod = dec.modification
   return Object.assign(
-    {'identifier': ident},
-    {'array_subscripts': arrSub ? this.arraySubscripts(arrSub) : undefined},
-    {'modification': mod ? this.modification(mod) : undefined}
+    { identifier: ident },
+    { array_subscripts: arrSub ? this.arraySubscripts(arrSub) : undefined },
+    { modification: mod ? this.modification(mod) : undefined }
   )
 }
 
@@ -377,10 +379,10 @@ function modification (mod) {
   const colEqu = mod.colon_equal
   const exp = mod.expression
   return Object.assign(
-    {'class_modification': claMod ? this.classModification(claMod) : undefined},
-    {'equal': equ || undefined},
-    {'colon_equal': colEqu || undefined},
-    {'expression': exp ? this.expression(exp) : undefined}
+    { class_modification: claMod ? this.classModification(claMod) : undefined },
+    { equal: equ || undefined },
+    { colon_equal: colEqu || undefined },
+    { expression: exp ? this.expression(exp) : undefined }
   )
 }
 
@@ -394,8 +396,8 @@ function classModification (claMod) {
   if (argLis) {
     const claModArr = []
     const args = argLis.arguments
-    for (var i = 0; i < args.length; i++) {
-      var ele = args[i]
+    for (let i = 0; i < args.length; i++) {
+      const ele = args[i]
       const eleModRep = ele.element_modification_or_replaceable
       const eleRed = ele.element_redeclaration
       // var eleModRepDict = {
@@ -405,8 +407,8 @@ function classModification (claMod) {
       //   'element_redeclaration': eleRed ? this.elementRedeclaration(eleRed) : undefined
       // }
       claModArr.push(Object.assign(
-        {'element_modification_or_replaceable': eleModRep ? this.elementModificationReplaceable(eleModRep) : undefined},
-        {'element_redeclaration': eleRed ? this.elementRedeclaration(eleRed) : undefined}
+        { element_modification_or_replaceable: eleModRep ? this.elementModificationReplaceable(eleModRep) : undefined },
+        { element_redeclaration: eleRed ? this.elementRedeclaration(eleRed) : undefined }
       ))
     }
     return claModArr
@@ -426,10 +428,10 @@ function elementModificationReplaceable (eleModRep) {
   const eleMod = eleModRep.element_modification
   const eleRep = eleModRep.element_replaceable
   return Object.assign(
-    {'each': each || undefined},
-    {'final': final || undefined},
-    {'element_modification': eleMod ? this.elementModification(eleMod) : undefined},
-    {'element_replaceable': eleRep ? this.elementReplaceable(eleRep) : undefined}
+    { each: each || undefined },
+    { final: final || undefined },
+    { element_modification: eleMod ? this.elementModification(eleMod) : undefined },
+    { element_replaceable: eleRep ? this.elementReplaceable(eleRep) : undefined }
   )
 }
 
@@ -446,14 +448,14 @@ function elementModification (eleMod) {
   if (isGraAnn) {
     const graMod = mod ? graPri.graphicAnnotationObj(name, this.modification(mod)) : undefined
     return Object.assign(
-      {[name]: graMod}
+      { [name]: graMod }
     )
   } else {
     // the 'name' could be string, or an object for the graphical annotation
     return Object.assign(
-      {'name': name},
-      {'modification': mod ? this.modification(mod) : undefined},
-      {'description_string': desStr}
+      { name },
+      { modification: mod ? this.modification(mod) : undefined },
+      { description_string: desStr }
     )
   }
 }
@@ -468,9 +470,9 @@ function elementReplaceable (eleRep) {
   const comCla1 = eleRep.component_clause1
   const conCla = eleRep.constraining_clause
   return Object.assign(
-    {'short_class_definition': shoClaDef ? this.shortClassDefinition(shoClaDef) : undefined},
-    {'component_clause1': comCla1 ? this.componentClause1(comCla1) : undefined},
-    {'constraining_clause': conCla ? this.constrainingClause(conCla) : undefined}
+    { short_class_definition: shoClaDef ? this.shortClassDefinition(shoClaDef) : undefined },
+    { component_clause1: comCla1 ? this.componentClause1(comCla1) : undefined },
+    { constraining_clause: conCla ? this.constrainingClause(conCla) : undefined }
   )
 }
 
@@ -483,8 +485,8 @@ function shortClassDefinition (shoClaDef) {
   const claPre = shoClaDef.class_prefixes
   const shoClaSpe = shoClaDef.short_class_specifier
   return Object.assign(
-    {'class_prefixes': claPre},
-    {'short_class_specifier': this.shortClassSpecifier(shoClaSpe)}
+    { class_prefixes: claPre },
+    { short_class_specifier: this.shortClassSpecifier(shoClaSpe) }
   )
 }
 
@@ -498,9 +500,9 @@ function componentClause1 (comCla1) {
   const typSpe = comCla1.type_specifier
   const comDec1 = comCla1.component_declaration1
   return Object.assign(
-    {'type_prefix': typPre},
-    {'type_specifier': this.typeSpecifier(typSpe)},
-    {'component_declaration1': this.componentDeclaration1(comDec1)}
+    { type_prefix: typPre },
+    { type_specifier: this.typeSpecifier(typSpe) },
+    { component_declaration1: this.componentDeclaration1(comDec1) }
   )
 }
 
@@ -514,8 +516,8 @@ function componentDeclaration1 (comDec1) {
   const des = comDec1.comment
   const desObj = des ? this.description(des) : undefined
   return Object.assign(
-    {'declaration': this.declaration(dec)},
-    {'description': !ut.isEmptyObject(desObj) ? desObj : undefined}
+    { declaration: this.declaration(dec) },
+    { description: !ut.isEmptyObject(desObj) ? desObj : undefined }
   )
 }
 
@@ -531,11 +533,11 @@ function elementRedeclaration (eleRed) {
   const comCla1 = eleRed.component_clause1
   const eleRep = eleRed.element_replaceable
   return Object.assign(
-    {'each': each || undefined},
-    {'final': final || undefined},
-    {'short_class_definition': shoClaDef ? this.shortClassDefinition(shoClaDef) : undefined},
-    {'component_clause1': comCla1 ? this.componentClause1(comCla1) : undefined},
-    {'element_replaceable': eleRep ? this.elementReplaceable(eleRep) : undefined}
+    { each: each || undefined },
+    { final: final || undefined },
+    { short_class_definition: shoClaDef ? this.shortClassDefinition(shoClaDef) : undefined },
+    { component_clause1: comCla1 ? this.componentClause1(comCla1) : undefined },
+    { element_replaceable: eleRep ? this.elementReplaceable(eleRep) : undefined }
   )
 }
 
@@ -546,17 +548,17 @@ function elementRedeclaration (eleRed) {
  */
 function elementSections (eleSec) {
   const secArr = []
-  for (var i = 0; i < eleSec.length; i++) {
-    var obj = eleSec[i]
+  for (let i = 0; i < eleSec.length; i++) {
+    const obj = eleSec[i]
     const pubEle = obj.public_element_list
     const proEle = obj.protected_element_list
     const equSec = obj.equation_section
     const algSec = obj.algorithm_section
     secArr.push(Object.assign(
-      {'public_element_list': pubEle ? this.elementList(pubEle) : undefined},
-      {'protected_element_list': proEle ? this.elementList(proEle) : undefined},
-      {'equation_section': equSec ? this.equationSection(equSec) : undefined},
-      {'algorithm_section': algSec ? this.algorithmSection(algSec) : undefined}
+      { public_element_list: pubEle ? this.elementList(pubEle) : undefined },
+      { protected_element_list: proEle ? this.elementList(proEle) : undefined },
+      { equation_section: equSec ? this.equationSection(equSec) : undefined },
+      { algorithm_section: algSec ? this.algorithmSection(algSec) : undefined }
     ))
   }
   return secArr
@@ -571,13 +573,13 @@ function equationSection (equSec) {
   const ini = equSec.initial
   const equLis = equSec.equations
   const equArr = []
-  for (var i = 0; i < equLis.length; i++) {
-    var obj = equLis[i]
+  for (let i = 0; i < equLis.length; i++) {
+    const obj = equLis[i]
     equArr.push(this.equation(obj))
   }
   return Object.assign(
-    {'initial': ini || undefined},
-    {'equation': equArr}
+    { initial: ini || undefined },
+    { equation: equArr }
   )
 }
 
@@ -596,13 +598,13 @@ function equation (equ) {
   const des = equ.comment
   const desObj = des ? this.description(des) : undefined
   return Object.assign(
-    {'assignment_equation': (assEqu && !ut.isEmptyObject(assEqu)) ? this.assignmentEquation(assEqu) : undefined},
-    {'if_equation': ifEqu ? this.ifEquation(ifEqu) : undefined},
-    {'for_equation': forEqu ? this.forEquation(forEqu) : undefined},
-    {'connect_clause': conCla ? this.connectClause(conCla) : undefined},
-    {'when_equation': wheEqu ? this.whenEquation(wheEqu) : undefined},
-    {'function_call_equation': (funCalEqu && !ut.isEmptyObject(funCalEqu)) ? this.functionCallEquation(funCalEqu) : undefined},
-    {'description': !ut.isEmptyObject(desObj) ? desObj : undefined}
+    { assignment_equation: (assEqu && !ut.isEmptyObject(assEqu)) ? this.assignmentEquation(assEqu) : undefined },
+    { if_equation: ifEqu ? this.ifEquation(ifEqu) : undefined },
+    { for_equation: forEqu ? this.forEquation(forEqu) : undefined },
+    { connect_clause: conCla ? this.connectClause(conCla) : undefined },
+    { when_equation: wheEqu ? this.whenEquation(wheEqu) : undefined },
+    { function_call_equation: (funCalEqu && !ut.isEmptyObject(funCalEqu)) ? this.functionCallEquation(funCalEqu) : undefined },
+    { description: !ut.isEmptyObject(desObj) ? desObj : undefined }
   )
 }
 
@@ -615,8 +617,8 @@ function assignmentEquation (assEqu) {
   const simExp = assEqu.lhs
   const exp = assEqu.rhs
   return Object.assign(
-    {'lhs': simExp ? this.simpleExpression(simExp) : undefined},
-    {'rhs': exp ? this.expression(exp) : undefined}
+    { lhs: simExp ? this.simpleExpression(simExp) : undefined },
+    { rhs: exp ? this.expression(exp) : undefined }
   )
 }
 
@@ -629,31 +631,31 @@ function ifEquation (ifEqu) {
   const ifEls = ifEqu.if_elseif
   const elsEqu = ifEqu.else_expression
   const ifElsArr = []
-  for (var i = 0; i < ifEls.length; i++) {
-    var obj = ifEls[i]
+  for (let i = 0; i < ifEls.length; i++) {
+    const obj = ifEls[i]
     const theEquArr = []
     const theEqu = obj.then
-    for (var j = 0; j < theEqu.length; j++) {
-      var ele = theEqu[j]
+    for (let j = 0; j < theEqu.length; j++) {
+      const ele = theEqu[j]
       theEquArr.push(Object.assign(
-        {'equation': this.equation(ele)}
+        { equation: this.equation(ele) }
       ))
     }
     ifElsArr.push(Object.assign(
-      {'condition': obj.condition ? this.expression(obj.condition) : undefined},
-      {'then': theEquArr}
+      { condition: obj.condition ? this.expression(obj.condition) : undefined },
+      { then: theEquArr }
     ))
   }
   const elsArr = []
   if (elsEqu) {
-    for (var k = 0; k < elsEqu.length; k++) {
-      var obj2 = elsEqu[k]
+    for (let k = 0; k < elsEqu.length; k++) {
+      const obj2 = elsEqu[k]
       elsArr.push(this.equation(obj2))
     }
   }
   return Object.assign(
-    {'if_elseif': ifElsArr},
-    {'else_equation': elsEqu ? elsArr : undefined}
+    { if_elseif: ifElsArr },
+    { else_equation: elsEqu ? elsArr : undefined }
   )
 }
 
@@ -666,13 +668,13 @@ function forEquation (forEqu) {
   const forInd = forEqu.for_indices
   const looEqu = forEqu.loop_equations
   const looEquArr = []
-  for (var i = 0; i < looEqu.length; i++) {
-    var obj = looEqu[i]
+  for (let i = 0; i < looEqu.length; i++) {
+    const obj = looEqu[i]
     looEquArr.push(this.equation(obj))
   }
   return Object.assign(
-    {'for_indices': this.forIndices(forInd)},
-    {'loop_equations': looEquArr}
+    { for_indices: this.forIndices(forInd) },
+    { loop_equations: looEquArr }
   )
 }
 
@@ -683,8 +685,8 @@ function forEquation (forEqu) {
  */
 function connectClause (conCla) {
   return Object.assign(
-    {'from': this.componentReference(conCla.from)},
-    {'to': this.componentReference(conCla.to)}
+    { from: this.componentReference(conCla.from) },
+    { to: this.componentReference(conCla.to) }
   )
 }
 
@@ -696,13 +698,13 @@ function connectClause (conCla) {
 function componentReference (comRef) {
   const comPar = comRef.component_reference_parts
   const parArr = []
-  for (var i = 0; i < comPar.length; i++) {
-    var obj = comPar[i]
+  for (let i = 0; i < comPar.length; i++) {
+    const obj = comPar[i]
     const arrSub = obj.array_subscripts
     parArr.push(Object.assign(
-      {'dot_op': obj.dot_op},
-      {'identifier': obj.identifier},
-      {'array_subscripts': arrSub ? this.arraySubscripts(arrSub) : undefined}
+      { dot_op: obj.dot_op },
+      { identifier: obj.identifier },
+      { array_subscripts: arrSub ? this.arraySubscripts(arrSub) : undefined }
     ))
   }
   return parArr
@@ -716,18 +718,18 @@ function componentReference (comRef) {
 function whenEquation (wheEqus) {
   const wheEqu = wheEqus.when_elsewhen
   const wheEquArr = []
-  for (var i = 0; i < wheEqu.length; i++) {
-    var obj = wheEqu[i]
+  for (let i = 0; i < wheEqu.length; i++) {
+    const obj = wheEqu[i]
     const con = obj.condition
     const the = obj.then
     const theArr = []
-    for (var j = 0; j < the.length; j++) {
-      var ele = the[j]
+    for (let j = 0; j < the.length; j++) {
+      const ele = the[j]
       theArr.push(this.equation(ele))
     }
     wheEquArr.push(Object.assign(
-      {'condition': con ? this.expression(con) : undefined},
-      {'then': theArr}
+      { condition: con ? this.expression(con) : undefined },
+      { then: theArr }
     ))
   }
   return wheEquArr
@@ -742,8 +744,8 @@ function functionCallEquation (funCalEqu) {
   const name = funCalEqu.function_name
   const funCalArg = funCalEqu.function_call_args
   return Object.assign(
-    {'function_name': name ? this.nameString(name) : undefined},
-    {'function_call_args': funCalArg ? this.functionCallArgs(funCalArg) : undefined}
+    { function_name: name ? this.nameString(name) : undefined },
+    { function_call_args: funCalArg ? this.functionCallArgs(funCalArg) : undefined }
   )
 }
 
@@ -768,10 +770,10 @@ function functionArguments (funArgs) {
   const forInd = funArgs.for_indices
   const intFunArgs = funArgs.function_arguments
   return Object.assign(
-    {'named_arguments': namArg ? this.namedArguments(namArg) : undefined},
-    {'function_argument': funArg ? this.functionArgument(funArg) : undefined},
-    {'for_indices': forInd ? this.forIndices(forInd) : undefined},
-    {'function_arguments': intFunArgs ? this.functionArguments(intFunArgs) : undefined}
+    { named_arguments: namArg ? this.namedArguments(namArg) : undefined },
+    { function_argument: funArg ? this.functionArgument(funArg) : undefined },
+    { for_indices: forInd ? this.forIndices(forInd) : undefined },
+    { function_arguments: intFunArgs ? this.functionArguments(intFunArgs) : undefined }
   )
 }
 
@@ -783,13 +785,13 @@ function functionArguments (funArgs) {
 function namedArguments (namArg) {
   const args = this.namedArgsArray(namArg)
   const namArgArr = []
-  for (var i = 0; i < args.length; i++) {
-    var obj = args[i]
+  for (let i = 0; i < args.length; i++) {
+    const obj = args[i]
     const ident = obj.identifier
     const val = obj.value
     namArgArr.push(Object.assign(
-      {'identifier': ident},
-      {'value': val ? this.functionArgument(val) : undefined}
+      { identifier: ident },
+      { value: val ? this.functionArgument(val) : undefined }
     ))
   }
   return namArgArr
@@ -805,10 +807,10 @@ function functionArgument (funArg) {
   const namArg = funArg.named_arguments
   const exp = funArg.expression
   return Object.assign(
-     {'function_name': name ? this.nameString(name) : undefined},
-     {'named_arguments': namArg ? this.namedArguments(namArg) : undefined},
-     {'expression': exp ? this.expression(exp) : undefined}
-   )
+    { function_name: name ? this.nameString(name) : undefined },
+    { named_arguments: namArg ? this.namedArguments(namArg) : undefined },
+    { expression: exp ? this.expression(exp) : undefined }
+  )
 }
 
 /**
@@ -819,12 +821,12 @@ function functionArgument (funArg) {
 function forIndices (forInd) {
   const indLis = forInd.indices
   const indArr = []
-  for (var i = 0; i < indLis.length; i++) {
-    var obj = indLis[i]
+  for (let i = 0; i < indLis.length; i++) {
+    const obj = indLis[i]
     const exp = obj.expression
     indArr.push(Object.assign(
-      {'identifier': obj.identifier},
-      {'expression': exp ? this.expression(exp) : undefined}
+      { identifier: obj.identifier },
+      { expression: exp ? this.expression(exp) : undefined }
     ))
   }
   return indArr
@@ -839,13 +841,13 @@ function algorithmSection (algSec) {
   const ini = algSec.initial
   const staLis = algSec.statements
   const staArr = []
-  for (var i = 0; i < staLis.length; i++) {
-    var obj = staLis[i]
+  for (let i = 0; i < staLis.length; i++) {
+    const obj = staLis[i]
     staArr.push(this.statement(obj))
   }
   return Object.assign(
-    {'initial': ini || undefined},
-    {'statement': staArr}
+    { initial: ini || undefined },
+    { statement: staArr }
   )
 }
 
@@ -867,16 +869,16 @@ function statement (sta) {
   const isBreak = sta.is_break
   const isReturn = sta.is_return
   return Object.assign(
-    {'assignment_statement': assSta ? this.assignmentStatement(assSta) : undefined},
-    {'Function_call_statement': funCalSta ? this.functionCallStatement(funCalSta) : undefined},
-    {'assignment_with_function_call_statement': assWithFunCalSta ? this.assignmentWithFunctionCallStatement(assWithFunCalSta) : undefined},
-    {'break': isBreak || undefined},
-    {'return': isReturn || undefined},
-    {'if_statement': ifSta ? this.ifStatement(ifSta) : undefined},
-    {'for_statement': forSta ? this.forStatement(forSta) : undefined},
-    {'while_statement': whiSta ? this.whileStatement(whiSta) : undefined},
-    {'when_statement': wheSta ? this.whenStatement(wheSta) : undefined},
-    {'description': !ut.isEmptyObject(desObj) ? desObj : undefined}
+    { assignment_statement: assSta ? this.assignmentStatement(assSta) : undefined },
+    { Function_call_statement: funCalSta ? this.functionCallStatement(funCalSta) : undefined },
+    { assignment_with_function_call_statement: assWithFunCalSta ? this.assignmentWithFunctionCallStatement(assWithFunCalSta) : undefined },
+    { break: isBreak || undefined },
+    { return: isReturn || undefined },
+    { if_statement: ifSta ? this.ifStatement(ifSta) : undefined },
+    { for_statement: forSta ? this.forStatement(forSta) : undefined },
+    { while_statement: whiSta ? this.whileStatement(whiSta) : undefined },
+    { when_statement: wheSta ? this.whenStatement(wheSta) : undefined },
+    { description: !ut.isEmptyObject(desObj) ? desObj : undefined }
   )
 }
 
@@ -889,8 +891,8 @@ function assignmentStatement (assSta) {
   const ident = assSta.identifier
   const val = assSta.value
   return Object.assign(
-    {'identifier': ident ? this.componentReference(ident) : undefined},
-    {'value': val ? this.expression(val) : undefined}
+    { identifier: ident ? this.componentReference(ident) : undefined },
+    { value: val ? this.expression(val) : undefined }
   )
 }
 
@@ -903,8 +905,8 @@ function functionCallStatement (funCalSta) {
   const name = funCalSta.function_name
   const funCalArg = funCalSta.function_call_args
   return Object.assign(
-    {'function_name': name ? this.componentReference(name) : undefined},
-    {'function_call_args': funCalArg ? this.functionCallArgs(funCalArg) : undefined}
+    { function_name: name ? this.componentReference(name) : undefined },
+    { function_call_args: funCalArg ? this.functionCallArgs(funCalArg) : undefined }
   )
 }
 
@@ -916,17 +918,17 @@ function functionCallStatement (funCalSta) {
 function assignmentWithFunctionCallStatement (assWithFunCalSta) {
   const outExpLis = assWithFunCalSta.output_expression_list
   const outExpArr = []
-  for (var i = 0; i < outExpLis.length; i++) {
-    var obj = outExpLis[i]
-    var objExp = obj.expression
+  for (let i = 0; i < outExpLis.length; i++) {
+    const obj = outExpLis[i]
+    const objExp = obj.expression
     if (objExp) { outExpArr.push(this.expression(objExp)) }
   }
   const name = assWithFunCalSta.function_name
   const funCalArg = assWithFunCalSta.function_call_args
   return Object.assign(
-    {'output_expression_list': outExpArr},
-    {'function_name': name ? this.componentReference(name) : undefined},
-    {'function_call_args': funCalArg ? this.functionCallArgs(funCalArg) : undefined}
+    { output_expression_list: outExpArr },
+    { function_name: name ? this.componentReference(name) : undefined },
+    { function_call_args: funCalArg ? this.functionCallArgs(funCalArg) : undefined }
   )
 }
 
@@ -939,29 +941,29 @@ function ifStatement (ifSta) {
   const ifEls = ifSta.if_elseif
   const elsSta = ifSta.else_statement
   const ifElsArr = []
-  for (var i = 0; i < ifEls.length; i++) {
-    var obj = ifEls[i]
+  for (let i = 0; i < ifEls.length; i++) {
+    const obj = ifEls[i]
     const theStaArr = []
     const theSta = obj.then
-    for (var j = 0; j < theSta.length; j++) {
-      var ele = theSta[j]
+    for (let j = 0; j < theSta.length; j++) {
+      const ele = theSta[j]
       theStaArr.push(this.statement(ele))
     }
     ifElsArr.push(Object.assign(
-      {'condition': obj.condition ? this.expression(obj.condition) : undefined},
-      {'then': theStaArr}
+      { condition: obj.condition ? this.expression(obj.condition) : undefined },
+      { then: theStaArr }
     ))
   }
   const elsArr = []
   if (elsSta && (elsSta.length > 0)) {
-    for (var k = 0; k < elsSta.length; k++) {
-      var obj2 = elsSta[k]
+    for (let k = 0; k < elsSta.length; k++) {
+      const obj2 = elsSta[k]
       elsArr.push(this.statement(obj2))
     }
   }
   return Object.assign(
-    {'if_elseif': ifElsArr},
-    {'else_statement': (elsArr.length > 0) ? elsArr : undefined}
+    { if_elseif: ifElsArr },
+    { else_statement: (elsArr.length > 0) ? elsArr : undefined }
   )
 }
 
@@ -974,13 +976,13 @@ function forStatement (forSta) {
   const forInd = forSta.for_indices
   const looSta = forSta.loop_statements
   const looStaArr = []
-  for (var i = 0; i < looSta.length; i++) {
-    var obj = looSta[i]
+  for (let i = 0; i < looSta.length; i++) {
+    const obj = looSta[i]
     looStaArr.push(this.statement(obj))
   }
   return Object.assign(
-    {'for_indices': this.forIndices(forInd)},
-    {'loop_statements': looStaArr}
+    { for_indices: this.forIndices(forInd) },
+    { loop_statements: looStaArr }
   )
 }
 
@@ -993,13 +995,13 @@ function whileStatement (whiSta) {
   const con = whiSta.condition
   const looSta = whiSta.loop_statements
   const staArr = []
-  for (var i = 0; i < looSta.length; i++) {
-    var obj = looSta[i]
+  for (let i = 0; i < looSta.length; i++) {
+    const obj = looSta[i]
     staArr.push(this.statement(obj))
   }
   return Object.assign(
-    {'condition': con ? this.expression(con) : undefined},
-    {'loop_statement': staArr}
+    { condition: con ? this.expression(con) : undefined },
+    { loop_statement: staArr }
   )
 }
 
@@ -1011,18 +1013,18 @@ function whileStatement (whiSta) {
 function whenStatement (wheStas) {
   const wheSta = wheStas.when_elsewhen
   const wheStaArr = []
-  for (var i = 0; i < wheSta.length; i++) {
-    var obj = wheSta[i]
+  for (let i = 0; i < wheSta.length; i++) {
+    const obj = wheSta[i]
     const con = obj.condition
     const the = obj.then
     const theArr = []
-    for (var j = 0; j < the.length; j++) {
-      var ele = the[j]
+    for (let j = 0; j < the.length; j++) {
+      const ele = the[j]
       theArr.push(this.statement(ele))
     }
     wheStaArr.push(Object.assign(
-      {'condition': con ? this.expression(con) : undefined},
-      {'then': theArr}
+      { condition: con ? this.expression(con) : undefined },
+      { then: theArr }
     ))
   }
   return wheStaArr
@@ -1039,9 +1041,9 @@ function externalComposition (extCom) {
   const extAnn = extCom.external_annotation ? extCom.external_annotation.class_modification : null
   const annotation = extAnn ? this.classModification(extAnn) : undefined
   return Object.assign(
-    {'language_specification': lanSpe},
-    {'external_function_call': extFunCal ? this.externalFunctionCall(extFunCal) : undefined},
-    {'external_annotation': (annotation === '()') ? undefined : annotation}
+    { language_specification: lanSpe },
+    { external_function_call: extFunCal ? this.externalFunctionCall(extFunCal) : undefined },
+    { external_annotation: (annotation === '()') ? undefined : annotation }
   )
 }
 
@@ -1057,15 +1059,15 @@ function externalFunctionCall (extFunCal) {
   const exps = expLis ? expLis.expressions : undefined
   const expArr = []
   if (exps) {
-    for (var i = 0; i < exps.length; i++) {
-      var ele = exps[i]
+    for (let i = 0; i < exps.length; i++) {
+      const ele = exps[i]
       expArr.push(this.expression(ele))
     }
   }
   return Object.assign(
-    {'component_reference': comRef ? this.componentReference(comRef) : undefined},
-    {'identifier': ident},
-    {'expression_list': exps ? expArr : undefined}
+    { component_reference: comRef ? this.componentReference(comRef) : undefined },
+    { identifier: ident },
+    { expression_list: exps ? expArr : undefined }
   )
 }
 
@@ -1078,8 +1080,8 @@ function shortClassSpecifier (shoClaSpe) {
   const ident = shoClaSpe.identifier
   const val = shoClaSpe.short_class_specifier_value
   return Object.assign(
-    {'identifier': ident},
-    {'value': val ? this.shortClassSpecifierValue(val) : undefined}
+    { identifier: ident },
+    { value: val ? this.shortClassSpecifierValue(val) : undefined }
   )
 }
 
@@ -1100,24 +1102,24 @@ function shortClassSpecifierValue (val) {
   const enuArr = []
   if (enuLis && (enuLis.enumeration_literal_list.length > 0)) {
     const enumLite = enuLis.enumeration_literal_list
-    for (var i = 0; i < enumLite.length; i++) {
-      var obj = enumLite[i]
+    for (let i = 0; i < enumLite.length; i++) {
+      const obj = enumLite[i]
       const ident = obj.identifier
       const desCri = obj.comment
       const desObj = desCri ? this.description(desCri) : undefined
       enuArr.push(Object.assign(
-        {'identifier': ident},
-        {'description': !ut.isEmptyObject(desObj) ? desObj : undefined}
+        { identifier: ident },
+        { description: !ut.isEmptyObject(desObj) ? desObj : undefined }
       ))
     }
   }
   return Object.assign(
-    {'base_prefix': pre},
-    {'name': name ? this.nameString(name) : undefined},
-    {'array_subscripts': arrSub ? this.arraySubscripts(arrSub) : undefined},
-    {'class_modification': claMod ? this.classModification(claMod) : undefined},
-    {'description': !ut.isEmptyObject(desObjEx) ? desObjEx : undefined},
-    {'enum_list': (enuArr.length > 0) ? enuArr : undefined}
+    { base_prefix: pre },
+    { name: name ? this.nameString(name) : undefined },
+    { array_subscripts: arrSub ? this.arraySubscripts(arrSub) : undefined },
+    { class_modification: claMod ? this.classModification(claMod) : undefined },
+    { description: !ut.isEmptyObject(desObjEx) ? desObjEx : undefined },
+    { enum_list: (enuArr.length > 0) ? enuArr : undefined }
   )
 }
 
@@ -1129,20 +1131,20 @@ function shortClassSpecifierValue (val) {
 function derClassSpecifier (derClaSpe) {
   const ident = derClaSpe.identifier
   const val = derClaSpe.der_class_specifier_value
-  var typSpe, typIden, typDes, valObj
+  let typSpe, typIden, typDes, valObj
   if (val) {
     typSpe = val.type_specifier
     typIden = val.identifiers
     typDes = val.comment ? this.description(val.comment) : undefined
     valObj = Object.assign(
-      {'type_specifier': typSpe},
-      {'identifier': typIden},
-      {'description': !ut.isEmptyObject(typDes) ? typDes : undefined}
+      { type_specifier: typSpe },
+      { identifier: typIden },
+      { description: !ut.isEmptyObject(typDes) ? typDes : undefined }
     )
   }
   return Object.assign(
-    {'identifier': ident},
-    {'value': val ? valObj : undefined}
+    { identifier: ident },
+    { value: val ? valObj : undefined }
   )
 }
 
@@ -1160,7 +1162,7 @@ function simpleExpression (simExp, outStr = false) {
   const logExp3 = simExp.logical_expression3
     ? (':' + this.logicalExpression(simExp.logical_expression3))
     : ''
-  var funCal, forLoo, logExp, ifExp
+  let funCal, forLoo, logExp, ifExp
   if (!(logExp2 || logExp3)) {
     const pri = this.checkPri(simExp.logical_expression1)
     if (pri) {
@@ -1172,19 +1174,19 @@ function simpleExpression (simExp, outStr = false) {
   }
   if ((funCal || forLoo || logExp || ifExp) && !outStr) {
     if (logExp) {
-      var logical_or = logExp.logical_or
-      if (logical_or.length == 1 && logical_or[0].logical_and.length == 1 &&
-          logical_or[0].logical_and[0].arithmetic_expressions.length == 1 &&
-          !logical_or[0].logical_and[0].not) {
-        return logical_or[0].logical_and[0].arithmetic_expressions[0].name
+      const logOr = logExp.logical_or
+      if (logOr.length === 1 && logOr[0].logical_and.length === 1 &&
+          logOr[0].logical_and[0].arithmetic_expressions.length === 1 &&
+          !logOr[0].logical_and[0].not) {
+        return logOr[0].logical_and[0].arithmetic_expressions[0].name
       } else {
-        return Object.assign({'logical_expression': logExp})
+        return Object.assign({ logical_expression: logExp })
       }
     } else {
       return Object.assign(
-        {'function_call': funCal},
-        {'for_loop': forLoo},
-        {'if_expression': ifExp}
+        { function_call: funCal },
+        { for_loop: forLoo },
+        { if_expression: ifExp }
       )
     }
   } else {
@@ -1201,28 +1203,28 @@ function ifExpressionObj (pri) {
   const outExpLis = pri.output_expression_list
   if (!outExpLis) { return undefined }
   const expLis = outExpLis.output_expressions
-  var expArray = []
-  for (var i = 0; i < expLis.length; i++) {
-    var ithExp = expLis[i]
+  const expArray = []
+  for (let i = 0; i < expLis.length; i++) {
+    const ithExp = expLis[i]
     if (ithExp.simple_expression) {
       return undefined
     }
-    var ifExp = ithExp.if_expression
-    var ifEls = ifExp.if_elseif
-    var ifElsArray = []
-    for (var j = 0; j < ifEls.length; j++) {
-      var jthEle = ifEls[j]
-      var condition = this.expressionString(jthEle.condition)
-      var then = this.expressionString(jthEle.then)
+    const ifExp = ithExp.if_expression
+    const ifEls = ifExp.if_elseif
+    const ifElsArray = []
+    for (let j = 0; j < ifEls.length; j++) {
+      const jthEle = ifEls[j]
+      const condition = this.expressionString(jthEle.condition)
+      const then = this.expressionString(jthEle.then)
       ifElsArray.push(Object.assign(
-        {'condition': condition},
-        {'then': then}
+        { condition },
+        { then }
       ))
     }
-    var elsExp = ifExp.else_expression
+    const elsExp = ifExp.else_expression
     expArray.push(Object.assign(
-      {'if_elseif': ifElsArray},
-      {'else': this.expressionString(elsExp)}
+      { if_elseif: ifElsArray },
+      { else: this.expressionString(elsExp) }
     ))
   }
   return (expArray.length > 0 ? expArray : undefined)
@@ -1239,7 +1241,7 @@ function forLoopObj (pri) {
   const forInd = funArgs.for_indices
   if (!forInd) { return undefined }
   const exp = this.funArgObj(funArg)
-  const forObj = Object.assign({'expression': exp}, this.forIndObj(forInd))
+  const forObj = Object.assign({ expression: exp }, this.forIndObj(forInd))
   return forObj
 }
 
@@ -1250,23 +1252,23 @@ function forLoopObj (pri) {
 function logicalExpressionObj (logExp) {
   const termList = logExp.logical_term_list
   const orArray = []
-  for (var i = 0; i < termList.length; i++) {
-    var ithTerm = termList[i]
-    var factorList = ithTerm.logical_factor_list
+  for (let i = 0; i < termList.length; i++) {
+    const ithTerm = termList[i]
+    const factorList = ithTerm.logical_factor_list
     const andArray = []
-    for (var j = 0; j < factorList.length; j++) {
-      var jthFactor = factorList[j]
-      var jthFactorObj = this.logicalFactorObj(jthFactor)
+    for (let j = 0; j < factorList.length; j++) {
+      const jthFactor = factorList[j]
+      const jthFactorObj = this.logicalFactorObj(jthFactor)
       if (jthFactorObj) {
         andArray.push(jthFactorObj)
       }
     }
     if (andArray.length > 0) {
-      orArray.push(Object.assign({'logical_and': andArray}))
+      orArray.push(Object.assign({ logical_and: andArray }))
     }
   }
   if (orArray.length > 0) {
-    return Object.assign({'logical_or': orArray})
+    return Object.assign({ logical_or: orArray })
   }
 }
 
@@ -1280,15 +1282,15 @@ function logicalFactorObj (fac) {
   const relOp = rel.rel_op
   const ariExp1 = this.arithmeticExpression(rel.arithmetic_expression1)
   const ariExpArray = []
-  ariExpArray.push(Object.assign({'name': ariExp1}))
+  ariExpArray.push(Object.assign({ name: ariExp1 }))
   if (relOp) {
     const ariExp2 = this.arithmeticExpression(rel.arithmetic_expression2)
-    ariExpArray.push(Object.assign({'name': ariExp2}))
+    ariExpArray.push(Object.assign({ name: ariExp2 }))
   }
   return Object.assign(
-    {'not': notOpe || undefined},
-    {'arithmetic_expressions': ariExpArray},
-    {'relation_operator': relOp || undefined}
+    { not: notOpe || undefined },
+    { arithmetic_expressions: ariExpArray },
+    { relation_operator: relOp || undefined }
   )
 }
 
@@ -1355,8 +1357,8 @@ function functionCallObj (pri) {
       return undefined
     }
     return Object.assign(
-      {'name': this.nameString(name)},
-      {'arguments': this.funCalArgObj(funCalArg)}
+      { name: this.nameString(name) },
+      { arguments: this.funCalArgObj(funCalArg) }
     )
   }
 }
@@ -1381,17 +1383,17 @@ function funArgsObj (argObj) {
   const funArgs = argObj.function_arguments
   const argArray = []
   if (namedArg) {
-    argArray.push(Object.assign({'name': this.namedArgsString(namedArg)}))
+    argArray.push(Object.assign({ name: this.namedArgsString(namedArg) }))
   } else {
     if (funArgs) {
-      argArray.push(Object.assign({'name': this.funArgString(funArg)}))
-      argArray.push(Object.assign({'name': this.funArgsString(funArgs)}))
+      argArray.push(Object.assign({ name: this.funArgString(funArg) }))
+      argArray.push(Object.assign({ name: this.funArgsString(funArgs) }))
     } else if (forInd) {
       const exp = this.funArgObj(funArg)
-      const forObj = Object.assign({'expression': exp}, this.forIndObj(forInd))
+      const forObj = Object.assign({ expression: exp }, this.forIndObj(forInd))
       argArray.push(forObj)
     } else {
-      argArray.push(Object.assign({'name': this.funArgString(funArg)}))
+      argArray.push(Object.assign({ name: this.funArgString(funArg) }))
     }
   }
   return argArray
@@ -1404,14 +1406,14 @@ function funArgsObj (argObj) {
 function forIndObj (forIndObject) {
   const ind = forIndObject.indices
   const indices = []
-  for (var i = 0; i < ind.length; i++) {
+  for (let i = 0; i < ind.length; i++) {
     const ithInd = ind[i]
     const ident = ithInd.identifier
     const exp = ithInd.expression
     const expString = exp ? this.expressionString(exp, false) : undefined
-    indices.push(Object.assign({'name': ident}, {'range': expString}))
+    indices.push(Object.assign({ name: ident }, { range: expString }))
   }
-  return Object.assign({'for_loop': indices})
+  return Object.assign({ for_loop: indices })
 }
 
 /** Get the for function argument object
@@ -1435,10 +1437,10 @@ function funArgObj (funArg) {
 function logicalExpression (logExp) {
   const termList = logExp.logical_term_list
   const termArray = []
-  for (var i = 0; i < termList.length; i++) {
+  for (let i = 0; i < termList.length; i++) {
     const factorList = termList[i].logical_factor_list
     const factor = []
-    for (var j = 0; j < factorList.length; j++) {
+    for (let j = 0; j < factorList.length; j++) {
       factor.push(this.logicalFactor(factorList[j]))
     }
     termArray.push(factor.join(' and '))
@@ -1480,7 +1482,7 @@ function relation (rel) {
 function arithmeticExpression (ariExp) {
   const termList = ariExp.arithmetic_term_list
   const termArray = []
-  for (var i = 0; i < termList.length; i++) {
+  for (let i = 0; i < termList.length; i++) {
     const addOp = termList[i].add_op
     const term = this.termString(termList[i].term)
     const termEle = addOp ? (addOp + term) : term
@@ -1497,10 +1499,10 @@ function arithmeticExpression (ariExp) {
 function termString (ter) {
   const factor = ter.factors
   const mulOps = ter.mul_ops
-  var temp
+  let temp
   if (mulOps) {
     temp = this.factorString(factor[0])
-    for (var i = 0; i < mulOps.length; i++) {
+    for (let i = 0; i < mulOps.length; i++) {
       temp = temp + mulOps[i] + this.factorString(factor[i + 1])
     }
   }
@@ -1573,7 +1575,7 @@ function funCalPriString (funCalPri) {
   const name = funCalPri.function_name
   const der = funCalPri.der
   const initial = funCalPri.initial
-  var pre
+  let pre
   if (name) {
     pre = this.nameString(name)
   } else if (der) {
@@ -1591,8 +1593,8 @@ function funCalPriString (funCalPri) {
  */
 function nameString (name) {
   const nameList = name.name_parts
-  var nameString = ''
-  for (var i = 0; i < nameList.length; i++) {
+  let nameString = ''
+  for (let i = 0; i < nameList.length; i++) {
     const dotOp = nameList[i].dot_op
     const dot = dotOp ? '.' : ''
     const ident = nameList[i].identifier
@@ -1618,8 +1620,8 @@ function funCalArgString (funCalArg) {
  */
 function comRefString (comRef) {
   const comRefPar = comRef.component_reference_parts
-  var comString = ''
-  for (var i = 0; i < comRefPar.length; i++) {
+  let comString = ''
+  for (let i = 0; i < comRefPar.length; i++) {
     const ithCom = comRefPar[i]
     const dotOp = ithCom.dot_op ? '.' : ''
     const ident = ithCom.identifier
@@ -1639,7 +1641,7 @@ function comRefString (comRef) {
 function arrSubString (arrSub) {
   const sub = arrSub.subscripts
   const subEle = []
-  for (var i = 0; i < sub.length; i++) {
+  for (let i = 0; i < sub.length; i++) {
     const ithSub = sub[i]
     const exp = ithSub.expression
     const colOp = ithSub.colon_op
@@ -1682,10 +1684,10 @@ function funArgString (funArgObj) {
   const namArgs = funArgObj.named_arguments
   const expStr = funArgObj.expression
   if (funName) {
-    var namedArgString = namArgs ? ('(' + this.namedArgsString(namArgs) + ')') : '()'
+    const namedArgString = namArgs ? ('(' + this.namedArgsString(namArgs) + ')') : '()'
     return 'function ' + this.nameString(funName) + namedArgString
   } else {
-    var funcArg = this.expressionString(expStr, true)
+    const funcArg = this.expressionString(expStr, true)
     return funcArg
   }
 }
@@ -1696,12 +1698,12 @@ function funArgString (funArgObj) {
  * @param namArgs named_arguments object
  */
 function namedArgsString (namArgs) {
-  var namArgsArr = this.namedArgsArray(namArgs)
+  const namArgsArr = this.namedArgsArray(namArgs)
   if (namArgsArr.length > 1) {
-    var namArr = []
-    for (var i = 0; i < namArgsArr.length; i++) {
-      var ident = namArgsArr[i].identifier
-      var value = this.funArgString(namArgsArr[i].value)
+    const namArr = []
+    for (let i = 0; i < namArgsArr.length; i++) {
+      const ident = namArgsArr[i].identifier
+      const value = this.funArgString(namArgsArr[i].value)
       namArr.push(ident + '=' + value)
     }
     return namArr.join(',')
@@ -1716,11 +1718,11 @@ function namedArgsString (namArgs) {
  * @param namArgs named_arguments object
  */
 function namedArgsArray (namArgs) {
-  var out = []
+  const out = []
   out.push(namArgs.named_argument)
-  var namArgsInt = namArgs.named_arguments
+  const namArgsInt = namArgs.named_arguments
   if (namArgsInt) {
-    var intArr = this.namedArgsArray(namArgsInt)
+    const intArr = this.namedArgsArray(namArgsInt)
     Array.prototype.push.apply(out, intArr)
   }
   return out
@@ -1734,7 +1736,7 @@ function namedArgsArray (namArgs) {
 function outExpLisString (outExpLis) {
   const expList = outExpLis.output_expressions
   const arr = []
-  for (var i = 0; i < expList.length; i++) {
+  for (let i = 0; i < expList.length; i++) {
     arr.push(this.expressionString(expList[i]))
   }
   return arr.join(',')
@@ -1747,7 +1749,7 @@ function outExpLisString (outExpLis) {
  */
 function expLisString (expLists) {
   const expString = []
-  for (var i = 0; i < expLists.length; i++) {
+  for (let i = 0; i < expLists.length; i++) {
     const expList = expLists[i]
     expString.push(this.expressionListString(expList))
   }
@@ -1763,7 +1765,7 @@ function expressionListString (expList) {
   const ithListEle = expList.expressions
   const arr = []
   if (ithListEle) {
-    for (var j = 0; j < ithListEle.length; j++) {
+    for (let j = 0; j < ithListEle.length; j++) {
       arr.push(this.expressionString(ithListEle[j]))
     }
     const ithListString = arr.join(',')
@@ -1780,7 +1782,7 @@ function expressionListString (expList) {
 function forIndString (forInd) {
   const ind = forInd.indices
   const indEle = []
-  for (var i = 0; i < ind.length; i++) {
+  for (let i = 0; i < ind.length; i++) {
     const ithInd = ind[i]
     const ident = ithInd.identifier
     const exp = ithInd.expression
@@ -1809,9 +1811,9 @@ function expressionString (exp, outStr = false) {
 function ifExpString (ifExp) {
   const ifElse = ifExp.if_elseif
   const elsExp = ifExp.else_expression
-  var ifExpString = 'if ' + this.expressionString(ifElse[0].condition) + ' then ' + this.expressionString(ifElse[0].then)
+  let ifExpString = 'if ' + this.expressionString(ifElse[0].condition) + ' then ' + this.expressionString(ifElse[0].then)
   if (ifElse.length > 1) {
-    for (var i = 1; i < ifElse.length; i++) {
+    for (let i = 1; i < ifElse.length; i++) {
       const ithEle = ifElse[i]
       const elseifString = ' elseif ' + this.expressionString(ithEle.condition) + ' then ' + this.expressionString(ithEle.then)
       ifExpString = ifExpString + elseifString

--- a/lib/modelicaToJSON.js
+++ b/lib/modelicaToJSON.js
@@ -2,7 +2,7 @@
 const pa = require('path')
 const pro = require('child_process')
 const fs = require('bluebird').promisifyAll(require('fs'))
-var logger = require('winston')
+const logger = require('winston')
 const ut = require('../lib/util.js')
 
 /** Parses the modelica file and returns a promise.
@@ -19,7 +19,7 @@ function toJSON (modelicaFile) {
     throw new Error(msg)
   }
   if (!fs.existsSync(modelicaFile)) {
-    var msg = "Modelica file '" + modelicaFile + "' not found. You may need to set the MODELICAPATH environment variable."
+    const msg = "Modelica file '" + modelicaFile + "' not found. You may need to set the MODELICAPATH environment variable."
     logger.error(msg)
     throw new Error(msg)
   }
@@ -28,7 +28,7 @@ function toJSON (modelicaFile) {
 
   // call synchronously
   const jr = pro.spawnSync('java',
-    ['-Xmx2048m', '-Xms512m', '-jar', parser, '--mo', modelicaFile], {maxBuffer: 1024 * 1024 * 100})
+    ['-Xmx2048m', '-Xms512m', '-jar', parser, '--mo', modelicaFile], { maxBuffer: 1024 * 1024 * 100 })
   if (jr.stderr.length > 0) {
     const msg = '*** Error when parsing ' + modelicaFile + ': "' + jr.stderr + '".'
     logger.error(msg)
@@ -36,12 +36,12 @@ function toJSON (modelicaFile) {
   } else {
     try {
       logger.debug('Parsing output to json.')
-      var res = JSON.parse(jr.stdout)
+      const res = JSON.parse(jr.stdout)
       // Add the modelica file name, as this is needed to look up its instances
       if (!res) throw new Error('Parser returned null instead of json structure. Did you install Java properly?')
       Object.assign(res,
-        { 'modelicaFile': ut.relativePath(modelicaFile) },
-        { 'fullMoFilePath': modelicaFile })
+        { modelicaFile: ut.relativePath(modelicaFile) },
+        { fullMoFilePath: modelicaFile })
       return res
     } catch (error) {
       const em = error + '\n JSON structure is \n' + jr.stdout

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -1,7 +1,7 @@
 const jq = require('../lib/jsonquery.js')
 const mj = require('../lib/modelicaToJSON.js')
 const ut = require('../lib/util.js')
-var logger = require('winston')
+const logger = require('winston')
 const fs = require('bluebird').promisifyAll(require('fs'))
 
 const storedDefiniton = require('../json2mo/storedDefiniton')
@@ -19,31 +19,31 @@ const storedDefiniton = require('../json2mo/storedDefiniton')
  */
 function getJsons (moFiles, parseMode, outputFormat, directory, prettyPrint) {
   logger.debug('Entered parser.getJsons.')
-  var jsonData = []
-  var outDir = directory
+  const jsonData = []
+  let outDir = directory
   if (directory === 'current') {
     outDir = process.cwd()
   }
   if (outputFormat === 'raw-json') {
     moFiles.forEach(function (obj) {
       // find the output file path
-      var outputFileName = ut.getOutputFile(obj, 'raw-json', outDir)
+      const outputFileName = ut.getOutputFile(obj, 'raw-json', outDir)
       // find the modelica file checksum
-      var resChecksum = ut.getMoChecksum(obj)
+      const resChecksum = ut.getMoChecksum(obj)
       // check if the file should be parsed
-      var needParsed = ut.checkIfParse(outputFileName, resChecksum, obj)
+      const needParsed = ut.checkIfParse(outputFileName, resChecksum, obj)
       if (needParsed) {
-        var rawJson = getRawJson(obj, outputFormat)
-        Object.assign(rawJson, {'checksum': resChecksum})
-        var out = (prettyPrint === 'true') ? JSON.stringify(rawJson, null, 2) : JSON.stringify(rawJson)
+        const rawJson = getRawJson(obj, outputFormat)
+        Object.assign(rawJson, { checksum: resChecksum })
+        const out = (prettyPrint === 'true') ? JSON.stringify(rawJson, null, 2) : JSON.stringify(rawJson)
         ut.writeFile(outputFileName, out)
       }
     })
   } else {
     const tempJsonDir = ut.createTempDir('json')
-    var parsedFile = []
-    for (var i = 0; i < moFiles.length; i++) {
-      var fileList = getSimpleJson(moFiles[i], parseMode, tempJsonDir, parsedFile, outDir, prettyPrint)
+    const parsedFile = []
+    for (let i = 0; i < moFiles.length; i++) {
+      const fileList = getSimpleJson(moFiles[i], parseMode, tempJsonDir, parsedFile, outDir, prettyPrint)
       parsedFile.push(fileList)
     }
     ut.copyFolderSync(tempJsonDir, outDir)
@@ -61,7 +61,7 @@ function getJsons (moFiles, parseMode, outputFormat, directory, prettyPrint) {
 function getRawJson (moFile, outputFormat) {
   const rawJson = mj.toJSON(moFile)
   if (outputFormat === 'raw-json') {
-    delete rawJson['fullMoFilePath']
+    delete rawJson.fullMoFilePath
   }
   return rawJson
 }
@@ -77,29 +77,29 @@ function getRawJson (moFile, outputFormat) {
  * @param prettyPrint Flag to indicate if prettify JSON output
  */
 function getSimpleJson (moFile, parseMode, tempDir, parsedFile, outDir, prettyPrint) {
-  var outputFileName = ut.getOutputFile(moFile, 'json', outDir)
+  const outputFileName = ut.getOutputFile(moFile, 'json', outDir)
   // find the modelica file checksum
-  var moChecksum = ut.getMoChecksum(moFile)
+  const moChecksum = ut.getMoChecksum(moFile)
   // check if the file should be parsed
-  var needParsed = ut.checkIfParse(outputFileName, moChecksum, moFile)
+  const needParsed = ut.checkIfParse(outputFileName, moChecksum, moFile)
   // if the moFile has been parsed and the original moFile has no change
   if (!needParsed || parsedFile.includes(moFile)) {
     return null
   }
   // get the raw-json output, this process will add relative and full modelica file path to the json output
-  var rawJson = getRawJson(moFile, 'json')
-  Object.assign(rawJson, {'checksum': moChecksum})
-  var da = jq.simplifyModelicaJSON(rawJson, parseMode)
+  const rawJson = getRawJson(moFile, 'json')
+  Object.assign(rawJson, { checksum: moChecksum })
+  const da = jq.simplifyModelicaJSON(rawJson, parseMode)
   // create temp directory to host the json output before adding the svg contents
-  var tempJsonPath = ut.getOutputFile(moFile, 'json', tempDir)
+  const tempJsonPath = ut.getOutputFile(moFile, 'json', tempDir)
   // write the simplified json output to file
-  var out = (prettyPrint === 'false') ? JSON.stringify(da) : JSON.stringify(da, null, 2)
+  const out = (prettyPrint === 'false') ? JSON.stringify(da) : JSON.stringify(da, null, 2)
   ut.writeFile(tempJsonPath, out)
   // add the full path to the list
-  var parsedPath = da.fullMoFilePath
+  const parsedPath = da.fullMoFilePath
   parsedFile.push(parsedPath)
   // get list of mo files instantiated by current mo file
-  var instantiateClass = getInstantiatedFile(da)
+  const instantiateClass = getInstantiatedFile(da)
   if (instantiateClass.length > 0) {
     instantiateClass.forEach(function (obj) {
       if (!parsedFile.includes(obj)) {
@@ -118,9 +118,9 @@ function getSimpleJson (moFile, parseMode, tempDir, parsedFile, outDir, prettyPr
 function getInstantiatedFile (data) {
   const within = data.within
   const claDef = data.class_definition
-  var insCla = []
+  let insCla = []
   claDef.forEach(function (obj) {
-    var claLis = instantiatedClass(within, obj)
+    const claLis = instantiatedClass(within, obj)
     if (claLis) {
       Array.prototype.push.apply(insCla, claLis)
     }
@@ -170,7 +170,7 @@ function instantiatedClass (within, claDef) {
     // Find all instantiated classes file path
     const pubInstancesFile = pubInstances ? instanceFilePath(pubInstances, within) : []
     const proInstancesFile = proInstances ? instanceFilePath(proInstances, within) : []
-    var instantitatedFiles = pubInstancesFile.concat(proInstancesFile)
+    let instantitatedFiles = pubInstancesFile.concat(proInstancesFile)
     // iteratively remove duplicate elements
     if (instantitatedFiles.length > 0) {
       instantitatedFiles = instantitatedFiles.filter(function (item, pos) { return instantitatedFiles.indexOf(item) === pos })
@@ -190,7 +190,7 @@ function instantiatedClass (within, claDef) {
  * @param within value of within object
  */
 function instanceFilePath (claObj, within) {
-  var fullList = []
+  let fullList = []
   const impCla = claObj.import_instance
   const extCla = claObj.extends_instance
   const conCla = claObj.constrained_instance
@@ -247,11 +247,11 @@ function searchInstances (eleLis) {
     }
   })
   return Object.assign(
-    {'import_instance': impEle},
-    {'extends_instance': extEle},
-    {'constrained_instance': conEle},
-    {'component_instance': comEle},
-    {'instance_in_modification': claModEle}
+    { import_instance: impEle },
+    { extends_instance: extEle },
+    { constrained_instance: conEle },
+    { component_instance: comEle },
+    { instance_in_modification: claModEle }
   )
 }
 
@@ -319,18 +319,18 @@ function elementReplaceable (eleRep) {
  * @returns string content of modelica file
  */
 function convertToModelica (jsonFile, outDir, rawJson = false) {
-  var fileContent = fs.readFileSync(jsonFile, 'utf8')
+  const fileContent = fs.readFileSync(jsonFile, 'utf8')
 
-  var jsonOutput
+  let jsonOutput
   if (rawJson) {
     jsonOutput = JSON.parse(fileContent)[0]
   } else {
     jsonOutput = JSON.parse(fileContent)
   }
-  var moOutput = storedDefiniton.parse(jsonOutput, rawJson)
+  const moOutput = storedDefiniton.parse(jsonOutput, rawJson)
 
   // find the output file path
-  var outputFileName = ut.getOutputFile(jsonFile, 'modelica', outDir)
+  const outputFileName = ut.getOutputFile(jsonFile, 'modelica', outDir)
   ut.writeFile(outputFileName, moOutput)
   return moOutput
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -22,7 +22,7 @@ function getMODELICAPATH () {
  * @param outputFormat output format, 'json'
  */
 function createTempDir (outputFormat) {
-  var tmpDir
+  let tmpDir
   try {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), outputFormat))
   } catch (e) {
@@ -67,11 +67,11 @@ function removeDir (directoryPath) {
  * @return array of the full path of the modelica file or the package
   */
 function getMoFiles (files) {
-  var moFiles = []
+  let moFiles = []
   const MODELICAPATH = getMODELICAPATH()
   if (files.endsWith('.mo')) {
-    var tempPath
-    for (var j = 0; j < MODELICAPATH.length; j++) {
+    let tempPath
+    for (let j = 0; j < MODELICAPATH.length; j++) {
       tempPath = path.join(MODELICAPATH[j], files)
       if (fse.existsSync(tempPath)) {
         moFiles.push(tempPath)
@@ -83,9 +83,9 @@ function getMoFiles (files) {
     }
   } else {
     // it is a package of mo files
-    var tempFolder = files
+    let tempFolder = files
     if (!fse.existsSync(tempFolder)) {
-      for (var i = 0; i < MODELICAPATH.length; i++) {
+      for (let i = 0; i < MODELICAPATH.length; i++) {
         tempFolder = path.join(MODELICAPATH[i], files)
         if (fse.existsSync(tempFolder)) break
       }
@@ -94,7 +94,7 @@ function getMoFiles (files) {
       // the package is not on the MODELICAPATH, so it is a user specified package
       tempFolder = files
     }
-    var fileList = getFiles(tempFolder)
+    const fileList = getFiles(tempFolder)
     moFiles = fileList.filter(function (obj) {
       return obj.endsWith('.mo')
     })
@@ -109,10 +109,11 @@ function getMoFiles (files) {
  */
 function getFiles (dir, fileList) {
   fileList = fileList || []
-  var files = fs.readdirSync(dir)
-  for (var i in files) {
-    if (!files.hasOwnProperty(i)) continue
-    var name = dir + path.sep + files[i]
+  const files = fs.readdirSync(dir)
+  for (const i in files) {
+    // if (!files.hasOwnProperty(i)) continue
+    if (!Object.prototype.hasOwnProperty.call(files, i)) continue
+    const name = dir + path.sep + files[i]
     if (fs.statSync(name).isDirectory()) {
       getFiles(name, fileList)
     } else {
@@ -130,14 +131,14 @@ function getFiles (dir, fileList) {
  * @return relative file path to MODELICAPATH
  */
 function relativePath (filePath) {
-  var paths = getMODELICAPATH()
-  var bases = []
+  const paths = getMODELICAPATH()
+  const bases = []
   paths.forEach(ele => {
-    var temp = path.parse(ele).base
+    const temp = path.parse(ele).base
     if (temp.length > 0) bases.push(temp)
   })
-  var relPa = filePath
-  for (var i = 0; i < bases.length; i++) {
+  let relPa = filePath
+  for (let i = 0; i < bases.length; i++) {
     if (filePath.includes(bases[i])) {
       relPa = filePath.substring(filePath.indexOf(bases[i]) + bases[i].length + 1)
     }
@@ -154,8 +155,8 @@ function relativePath (filePath) {
  */
 function getOutputFile (inputFile, outputFormat, dir) {
   // get the modelica file path from the Json output, it is relative path
-  var relPat = relativePath(inputFile)
-  var outFile
+  const relPat = relativePath(inputFile)
+  let outFile
   if (outputFormat === 'json' || outputFormat === 'raw-json') {
     outFile = relPat.replace('.mo', '.json')
   } else if (outputFormat === 'html') {
@@ -172,22 +173,22 @@ function getOutputFile (inputFile, outputFormat, dir) {
 function searchPath (claLis, within) {
   const MODELICAPATH = getMODELICAPATH()
   const filePath = []
-  for (var i = 0; i < claLis.length; i++) {
+  for (let i = 0; i < claLis.length; i++) {
     const ithCla = claLis[i]
     const claRelPath = joinedPathes(ithCla.split('.'))
-    var fulPat = searchFullPath(claRelPath.reverse(), MODELICAPATH, within)
+    const fulPat = searchFullPath(claRelPath.reverse(), MODELICAPATH, within)
     if (fulPat) {
       filePath.push(fulPat)
     }
   }
   return filePath
 }
- // Get array of potential paths
+// Get array of potential paths
 function joinedPathes (eleArr) {
   const pathes = []
   const joinedPat = []
   const pathSep = path.sep
-  for (var i = 0; i < eleArr.length; i++) {
+  for (let i = 0; i < eleArr.length; i++) {
     pathes.push(eleArr[i])
     joinedPat.push(pathes.join(pathSep))
   }
@@ -197,7 +198,7 @@ function joinedPathes (eleArr) {
 // Search the full path
 function searchFullPath (claRelPath, MODELICAPATH, within) {
   const withEle = within ? within.split('.') : null
-  var fullPath = pathSearch(claRelPath, MODELICAPATH, withEle, false)
+  let fullPath = pathSearch(claRelPath, MODELICAPATH, withEle, false)
   if (!fullPath) {
     fullPath = pathSearch(claRelPath, MODELICAPATH, withEle, true)
   }
@@ -214,14 +215,14 @@ function searchFullPath (claRelPath, MODELICAPATH, within) {
  * @param checkPackage flag to check if should check package.mo file
  */
 function pathSearch (claRelPath, MODELICAPATH, withEle, checkPackage) {
-  var fullPath
-  for (var i = 0; i < MODELICAPATH.length; i++) {
-    var moPath = MODELICAPATH[i]
+  let fullPath
+  for (let i = 0; i < MODELICAPATH.length; i++) {
+    const moPath = MODELICAPATH[i]
     const tempPathes = withEle ? joinWithinPath(moPath, withEle) : [moPath]
-    var tempPath
-    for (var j = 0; j < tempPathes.length; j++) {
-      for (var k = 0; k < claRelPath.length; k++) {
-        var relPath = !checkPackage ? (claRelPath[k] + '.mo') : claRelPath[k]
+    let tempPath
+    for (let j = 0; j < tempPathes.length; j++) {
+      for (let k = 0; k < claRelPath.length; k++) {
+        const relPath = !checkPackage ? (claRelPath[k] + '.mo') : claRelPath[k]
         tempPath = path.join(tempPathes[j], relPath)
         if (!checkPackage) {
           if (fse.existsSync(tempPath)) {
@@ -310,11 +311,11 @@ function copyFolderSync (from, to) {
 
 // Check if the modelica file should be parsed
 function checkIfParse (outputFile, checksum, moFile) {
-  var parseMo = false
+  let parseMo = false
   if (!fs.existsSync(outputFile)) {
     parseMo = true
   } else {
-    var checksumInJson = getChecksumFromJson(outputFile)
+    const checksumInJson = getChecksumFromJson(outputFile)
     if (!checksumInJson || (checksumInJson !== checksum)) {
       if (checksumInJson !== checksum) {
         console.log('There is change in: "' + moFile + '", regenerating the json output.')
@@ -331,18 +332,18 @@ function checkIfParse (outputFile, checksum, moFile) {
 // Get the checksum of the Modelica file
 function getMoChecksum (moFile) {
   const input = fs.readFileSync(moFile)
-  var hash = crypto.createHash('md5')
+  const hash = crypto.createHash('md5')
   hash.update(input)
   return hash.digest('hex')
 }
 
 // Get the checksum from the stored json file
 function getChecksumFromJson (jsPath) {
-  var jsonChecksum = null
+  let jsonChecksum = null
   try {
-    var fileContent = fs.readFileSync(jsPath, 'utf8')
-    var jsonOutput = JSON.parse(fileContent)
-    jsonChecksum = jsonOutput['checksum']
+    const fileContent = fs.readFileSync(jsPath, 'utf8')
+    const jsonOutput = JSON.parse(fileContent)
+    jsonChecksum = jsonOutput.checksum
     if (jsonChecksum == null) {
       return null
     }
@@ -354,20 +355,17 @@ function getChecksumFromJson (jsPath) {
 }
 
 // Validation of a json file against a schema
-function jsonSchemaValidation (mode, userData, output = 'json', userSchema) {
-  if (output !== 'json') {
+function jsonSchemaValidation (mode, userData, userSchema) {
+  const ajv = new Ajv({ allErrors: true, schemaId: '$id' })
+  const schema = JSON.parse(fs.readFileSync(userSchema, 'utf8'))
+  const data = JSON.parse(fs.readFileSync(userData, 'utf8'))
+  const valid = ajv.validate(schema, data)
+  if (valid) {
+    console.log('Json file is valid')
+    return valid
   } else {
-    var ajv = new Ajv({ allErrors: true, schemaId: '$id' })
-    var schema = JSON.parse(fs.readFileSync(userSchema, 'utf8'))
-    var data = JSON.parse(fs.readFileSync(userData, 'utf8'))
-    var valid = ajv.validate(schema, data)
-    if (valid) {
-      console.log('Json file is valid')
-      return valid
-    } else {
-      console.log('Json file not valid, see errors below in ', userData)
-      console.log(ajv.errorsText())
-    }
+    console.log('Json file not valid, see errors below in ', userData)
+    console.log(ajv.errorsText())
   }
 }
 
@@ -379,15 +377,15 @@ function jsonSchemaValidation (mode, userData, output = 'json', userSchema) {
  * @return             Result files with path string in an array
  */
 function findFilesInDir (startPath, filter) {
-  var results = []
+  let results = []
   if (!fs.existsSync(startPath)) {
     console.log('no dir ', startPath)
     return
   }
-  var files = fs.readdirSync(startPath)
-  for (var i = 0; i < files.length; i++) {
-    var filename = path.join(startPath, files[i])
-    var stat = fs.lstatSync(filename)
+  const files = fs.readdirSync(startPath)
+  for (let i = 0; i < files.length; i++) {
+    const filename = path.join(startPath, files[i])
+    const stat = fs.lstatSync(filename)
     if (stat.isDirectory()) {
       results = results.concat(findFilesInDir(filename, filter)) // recurse
     } else if (filename.indexOf(filter) >= 0) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "base64-img": "^1.0.1",
     "bluebird": "^3.5.1",
     "cheerio": "^1.0.0-rc.2",
+    "cross-env": "^7.0.3",
     "express": "^4.16.2",
     "find": "^0.2.8",
     "fs": "0.0.1-security",
@@ -36,7 +37,7 @@
   "devDependencies": {
     "chai": "^4.1.2",
     "mocha": "^9.1.3",
-    "standard": "^10.0.3",
-    "sinon": "^15.0.0"
+    "sinon": "^15.0.0",
+    "standard": "^17.0.0"
   }
 }

--- a/test/test_jsonquery.js
+++ b/test/test_jsonquery.js
@@ -17,9 +17,9 @@ function equalObjects (dict, reference) {
     if (Object.keys(dict).length !== Object.keys(reference).length) {
       return false
     }
-    var keys = Object.keys(dict).sort()
-    for (var i = 0; i < keys.length; i++) {
-      var idx = keys[i]
+    const keys = Object.keys(dict).sort()
+    for (let i = 0; i < keys.length; i++) {
+      const idx = keys[i]
       if (!(idx in reference)) {
         return false
       } else {
@@ -31,7 +31,7 @@ function equalObjects (dict, reference) {
     if (dict.length !== reference.length) {
       return false
     } else {
-      for (var j = 0; j < dict.length; j++) {
+      for (let j = 0; j < dict.length; j++) {
         if (!(equalObjects(dict[j], reference[j]))) {
           return false
         }
@@ -51,23 +51,23 @@ mo.describe('jsonquery.js', function () {
   mo.describe('testing classDefinition', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'classSpecifier').returns('mocked class_specifier')
-      var rawJson = {
-        'encapsulated': true,
-        'class_prefixes': 'partial',
-        'class_specifier': 'test class_specifier'
+      const rawJson = {
+        encapsulated: true,
+        class_prefixes: 'partial',
+        class_specifier: 'test class_specifier'
       }
-      var jsonOutput = jq.classDefinition(rawJson)
-      var referenceJsonOutput = {
-        'class_prefixes': 'partial',
-        'class_specifier': 'mocked class_specifier',
-        'encapsulated': true
+      const jsonOutput = jq.classDefinition(rawJson)
+      const referenceJsonOutput = {
+        class_prefixes: 'partial',
+        class_specifier: 'mocked class_specifier',
+        encapsulated: true
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
   })
   mo.describe('testing classSpecifier', function () {
     mo.it('checking for empty class_specifier -> should return an error', function () {
-      var rawJson = {}
+      const rawJson = {}
       try {
         jq.classSpecifier(rawJson)
         as.fail('no error raised for missing all of long_class_specifier, short_class_specifier and der_class_specifier')
@@ -77,34 +77,34 @@ mo.describe('jsonquery.js', function () {
     })
     mo.it('checking with long_class_specifier', function () {
       sinon.stub(jq, 'longClassSpecifier').returns('mocked long_class_specifier')
-      var rawJson = {
-        'long_class_specifier': 'test long_class_specifier'
+      const rawJson = {
+        long_class_specifier: 'test long_class_specifier'
       }
-      var jsonOutput = jq.classSpecifier(rawJson)
-      var referenceJsonOutput = {
-        'long_class_specifier': 'mocked long_class_specifier'
+      const jsonOutput = jq.classSpecifier(rawJson)
+      const referenceJsonOutput = {
+        long_class_specifier: 'mocked long_class_specifier'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
     mo.it('checking with short_class_specifier', function () {
       sinon.stub(jq, 'shortClassSpecifier').returns('mocked short_class_specifier')
-      var rawJson = {
-        'short_class_specifier': 'test short_class_specifier'
+      const rawJson = {
+        short_class_specifier: 'test short_class_specifier'
       }
-      var jsonOutput = jq.classSpecifier(rawJson)
-      var referenceJsonOutput = {
-        'short_class_specifier': 'mocked short_class_specifier'
+      const jsonOutput = jq.classSpecifier(rawJson)
+      const referenceJsonOutput = {
+        short_class_specifier: 'mocked short_class_specifier'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
     mo.it('checking with der_class_specifier', function () {
       sinon.stub(jq, 'derClassSpecifier').returns('mocked der_class_specifier')
-      var rawJson = {
-        'der_class_specifier': 'test der_class_specifier'
+      const rawJson = {
+        der_class_specifier: 'test der_class_specifier'
       }
-      var jsonOutput = jq.classSpecifier(rawJson)
-      var referenceJsonOutput = {
-        'der_class_specifier': 'mocked der_class_specifier'
+      const jsonOutput = jq.classSpecifier(rawJson)
+      const referenceJsonOutput = {
+        der_class_specifier: 'mocked der_class_specifier'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -114,31 +114,31 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'composition').returns('mocked composition')
       sinon.stub(jq, 'classModification').returns('mocked class_modification')
-      var rawJson = {
-        'identifier': 'test.identifier.a',
-        'string_comment': 'string comment',
-        'is_extends': false,
-        'composition': 'test composition',
-        'class_modification': 'test class_modification'
+      const rawJson = {
+        identifier: 'test.identifier.a',
+        string_comment: 'string comment',
+        is_extends: false,
+        composition: 'test composition',
+        class_modification: 'test class_modification'
       }
-      var jsonOutput = jq.longClassSpecifier(rawJson)
-      var referenceJsonOutput = {
-        'identifier': 'test.identifier.a',
-        'description_string': 'string comment',
-        'extends': false,
-        'composition': 'mocked composition',
-        'class_modification': 'mocked class_modification'
+      const jsonOutput = jq.longClassSpecifier(rawJson)
+      const referenceJsonOutput = {
+        identifier: 'test.identifier.a',
+        description_string: 'string comment',
+        extends: false,
+        composition: 'mocked composition',
+        class_modification: 'mocked class_modification'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
     mo.it('testing missing identifier', function () {
       sinon.stub(jq, 'composition').returns('mocked composition')
       sinon.stub(jq, 'classModification').returns('mocked class_modification')
-      var rawJson = {
-        'string_comment': 'string comment',
-        'is_extends': false,
-        'composition': 'test composition',
-        'class_modification': 'test class_modification'
+      const rawJson = {
+        string_comment: 'string comment',
+        is_extends: false,
+        composition: 'test composition',
+        class_modification: 'test class_modification'
       }
       try {
         jq.longClassSpecifier(rawJson)
@@ -148,13 +148,13 @@ mo.describe('jsonquery.js', function () {
       }
     })
     mo.it('testing missing composition', function () {
-      sinon.stub(jq, 'composition').returns({'composition': 'mocked composition'})
-      sinon.stub(jq, 'classModification').returns({'class_modification': 'mocked class_modification'})
-      var rawJson = {
-        'identifier': 'test.identifier.a',
-        'string_comment': 'string comment',
-        'is_extends': false,
-        'class_modification': 'test class_modification'
+      sinon.stub(jq, 'composition').returns({ composition: 'mocked composition' })
+      sinon.stub(jq, 'classModification').returns({ class_modification: 'mocked class_modification' })
+      const rawJson = {
+        identifier: 'test.identifier.a',
+        string_comment: 'string comment',
+        is_extends: false,
+        class_modification: 'test class_modification'
       }
       try {
         jq.longClassSpecifier(rawJson)
@@ -170,32 +170,32 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'elementSections').returns(['mocked element_section1', 'mocked element_section2'])
       sinon.stub(jq, 'classModification').returns('mocked class_modification')
       sinon.stub(jq, 'externalComposition').returns('mocked external_omposition')
-      var rawJson = {
-        'element_list': 'test element_list',
-        'element_sections': ['test element_section1', 'test element_section2'],
-        'annotation': {
-          'class_modification': 'test class_modification'
+      const rawJson = {
+        element_list: 'test element_list',
+        element_sections: ['test element_section1', 'test element_section2'],
+        annotation: {
+          class_modification: 'test class_modification'
         },
-        'external_composition': 'test external_composition'
+        external_composition: 'test external_composition'
       }
-      var jsonOutput = jq.composition(rawJson)
-      var referenceJsonOutput = {
-        'element_list': 'mocked element_list',
-        'element_sections': ['mocked element_section1', 'mocked element_section2'],
-        'annotation': 'mocked class_modification',
-        'external_composition': 'mocked external_composition'
+      const jsonOutput = jq.composition(rawJson)
+      const referenceJsonOutput = {
+        element_list: 'mocked element_list',
+        element_sections: ['mocked element_section1', 'mocked element_section2'],
+        annotation: 'mocked class_modification',
+        external_composition: 'mocked external_composition'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
     mo.it('testing missing element_list', function () {
-      sinon.stub(jq, 'elementList').returns({'element_list': 'mocked element_list'})
+      sinon.stub(jq, 'elementList').returns({ element_list: 'mocked element_list' })
       sinon.stub(jq, 'elementSections').returns(['mocked element_section1', 'mocked element_section2'])
-      sinon.stub(jq, 'classModification').returns({'class_modification': 'mocked class_modification'})
-      sinon.stub(jq, 'externalComposition').returns({'external_composition': 'mocked external_omposition'})
-      var rawJson = {
-        'element_sections': ['test element_section1', 'test element_section2'],
-        'annotation': 'test annotation',
-        'external_composition': 'test external_composition'
+      sinon.stub(jq, 'classModification').returns({ class_modification: 'mocked class_modification' })
+      sinon.stub(jq, 'externalComposition').returns({ external_composition: 'mocked external_omposition' })
+      const rawJson = {
+        element_sections: ['test element_section1', 'test element_section2'],
+        annotation: 'test annotation',
+        external_composition: 'test external_composition'
       }
       try {
         jq.composition(rawJson)
@@ -209,37 +209,37 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'elementModificationReplaceable').returns('mocked element_modification_or_replaceable')
       sinon.stub(jq, 'elementRedeclaration').returns('mocked element_redeclaration')
-      var rawJson = {
-        'argument_list': {
-          'arguments': [
+      const rawJson = {
+        argument_list: {
+          arguments: [
             {
-              'element_modification_or_replaceable': 'test element_modification_or_replaceable'
+              element_modification_or_replaceable: 'test element_modification_or_replaceable'
             },
             {
-              'element_redeclaration': 'test element_redeclaration'
+              element_redeclaration: 'test element_redeclaration'
             }
           ]
         }
       }
-      var jsonOutput = jq.classModification(rawJson)
-      var referenceJsonOutput = [
+      const jsonOutput = jq.classModification(rawJson)
+      const referenceJsonOutput = [
         {
-          'element_modification_or_replaceable': 'mocked element_modification_or_replaceable',
-          'element_redeclaration': undefined
+          element_modification_or_replaceable: 'mocked element_modification_or_replaceable',
+          element_redeclaration: undefined
         },
         {
-          'element_modification_or_replaceable': undefined,
-          'element_redeclaration': 'mocked element_redeclaration'
+          element_modification_or_replaceable: undefined,
+          element_redeclaration: 'mocked element_redeclaration'
         }
       ]
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
     mo.it('testing empty arguments', function () {
-      sinon.stub(jq, 'elementRedeclaration').returns({'element_redeclaration': 'mocked element_redeclaration'})
-      sinon.stub(jq, 'elementModificationReplaceable').returns({'element_modification_or_replaceble': 'mocked element_modification_or_replaceable'})
-      var rawJson = {}
-      var jsonOutput = jq.classModification(rawJson)
-      var referenceJsonOutput = '()'
+      sinon.stub(jq, 'elementRedeclaration').returns({ element_redeclaration: 'mocked element_redeclaration' })
+      sinon.stub(jq, 'elementModificationReplaceable').returns({ element_modification_or_replaceble: 'mocked element_modification_or_replaceable' })
+      const rawJson = {}
+      const jsonOutput = jq.classModification(rawJson)
+      const referenceJsonOutput = '()'
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
   })
@@ -250,91 +250,91 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'classDefinition').returns('mocked class_definition')
       sinon.stub(jq, 'componentClause').returns('mocked component_clause')
       sinon.stub(jq, 'constrainingClause').returns('mocked constraining_clause')
-      var rawJson = {
-        'elements': [
+      const rawJson = {
+        elements: [
           {
-            'import_clause': 'test import_clause'
+            import_clause: 'test import_clause'
           },
           {
-            'extends_clause': 'test extends_clause'
+            extends_clause: 'test extends_clause'
           },
           {
-            'redeclare': true,
-            'is_final': true,
-            'inner': true,
-            'outer': true,
-            'replaceable': true,
-            'class_definition': 'test class_definition',
-            'component_clause': 'test component_clause',
-            'constraining_clause': 'test constraining_clause',
-            'comment': {
-              'string_comment': 'test comment'
+            redeclare: true,
+            is_final: true,
+            inner: true,
+            outer: true,
+            replaceable: true,
+            class_definition: 'test class_definition',
+            component_clause: 'test component_clause',
+            constraining_clause: 'test constraining_clause',
+            comment: {
+              string_comment: 'test comment'
             }
           },
           {
-            'redeclare': true,
-            'is_final': true,
-            'inner': true,
-            'outer': true,
-            'replaceable': false,
-            'class_definition': 'test class_definition',
-            'component_clause': 'test component_clause'
+            redeclare: true,
+            is_final: true,
+            inner: true,
+            outer: true,
+            replaceable: false,
+            class_definition: 'test class_definition',
+            component_clause: 'test component_clause'
           }
         ]
       }
-      var jsonOutput = jq.elementList(rawJson)
-      var referenceJsonOutput = [
+      const jsonOutput = jq.elementList(rawJson)
+      const referenceJsonOutput = [
         {
-          'import_clause': 'mocked import_clause',
-          'extends_clause': undefined,
-          'redeclare': undefined,
-          'final': undefined,
-          'inner': undefined,
-          'outer': undefined,
-          'replaceable': undefined,
-          'class_definition': undefined,
-          'component_clause': undefined,
-          'constraining_clause': undefined,
-          'description': undefined
+          import_clause: 'mocked import_clause',
+          extends_clause: undefined,
+          redeclare: undefined,
+          final: undefined,
+          inner: undefined,
+          outer: undefined,
+          replaceable: undefined,
+          class_definition: undefined,
+          component_clause: undefined,
+          constraining_clause: undefined,
+          description: undefined
         }, {
-          'import_clause': undefined,
-          'extends_clause': 'mocked extends_clause',
-          'redeclare': undefined,
-          'final': undefined,
-          'inner': undefined,
-          'outer': undefined,
-          'replaceable': undefined,
-          'class_definition': undefined,
-          'component_clause': undefined,
-          'constraining_clause': undefined,
-          'description': undefined
+          import_clause: undefined,
+          extends_clause: 'mocked extends_clause',
+          redeclare: undefined,
+          final: undefined,
+          inner: undefined,
+          outer: undefined,
+          replaceable: undefined,
+          class_definition: undefined,
+          component_clause: undefined,
+          constraining_clause: undefined,
+          description: undefined
         }, {
-          'import_clause': undefined,
-          'extends_clause': undefined,
-          'redeclare': true,
-          'final': true,
-          'inner': true,
-          'outer': true,
-          'replaceable': true,
-          'class_definition': 'mocked class_definition',
-          'component_clause': 'mocked component_clause',
-          'constraining_clause': 'mocked constraining_clause',
-          'description': {
-            'description_string': 'test comment',
-            'annotation': undefined
+          import_clause: undefined,
+          extends_clause: undefined,
+          redeclare: true,
+          final: true,
+          inner: true,
+          outer: true,
+          replaceable: true,
+          class_definition: 'mocked class_definition',
+          component_clause: 'mocked component_clause',
+          constraining_clause: 'mocked constraining_clause',
+          description: {
+            description_string: 'test comment',
+            annotation: undefined
           }
         }, {
-          'import_clause': undefined,
-          'extends_clause': undefined,
-          'redeclare': true,
-          'final': true,
-          'inner': true,
-          'outer': true,
-          'replaceable': false,
-          'class_definition': 'mocked class_definition',
-          'component_clause': 'mocked component_clause',
-          'constraining_clause': undefined,
-          'description': undefined
+          import_clause: undefined,
+          extends_clause: undefined,
+          redeclare: true,
+          final: true,
+          inner: true,
+          outer: true,
+          replaceable: false,
+          class_definition: 'mocked class_definition',
+          component_clause: 'mocked component_clause',
+          constraining_clause: undefined,
+          description: undefined
         }
       ]
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
@@ -345,19 +345,19 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'classDefinition').returns('mocked class_definition')
       sinon.stub(jq, 'componentClause').returns('mocked component_clause')
       sinon.stub(jq, 'constrainingClause').returns('mocked constraining_clause')
-      var rawJson = {
-        'elements': [
+      const rawJson = {
+        elements: [
           {
-            'redeclare': true,
-            'is_final': true,
-            'inner': true,
-            'outer': true,
-            'replaceable': false,
-            'class_definition': 'test class_definition',
-            'component_clause': 'test component_clause',
-            'constraining_clause': 'test constraining_clause',
-            'comment': {
-              'string_comment': 'test comment'
+            redeclare: true,
+            is_final: true,
+            inner: true,
+            outer: true,
+            replaceable: false,
+            class_definition: 'test class_definition',
+            component_clause: 'test component_clause',
+            constraining_clause: 'test constraining_clause',
+            comment: {
+              string_comment: 'test comment'
             }
           }
         ]
@@ -376,42 +376,42 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'algorithmSection').returns('mocked algorithm_section')
       sinon.stub(jq, 'equationSection').returns('mocked equation_section')
 
-      var rawJson = [
+      const rawJson = [
         {
-          'public_element_list': 'test public_element_list'
+          public_element_list: 'test public_element_list'
         }, {
-          'protected_element_list': 'test protected_element_list'
+          protected_element_list: 'test protected_element_list'
         }, {
-          'algorithm_section': 'test algorithm_section'
+          algorithm_section: 'test algorithm_section'
         }, {
-          'equation_section': 'test equation_section'
+          equation_section: 'test equation_section'
         }
       ]
-      var jsonOutput = jq.elementSections(rawJson)
-      var referenceJsonOutput = [
+      const jsonOutput = jq.elementSections(rawJson)
+      const referenceJsonOutput = [
         {
-          'public_element_list': 'mocked public_element_list',
-          'protected_element_list': undefined,
-          'algorithm_section': undefined,
-          'equation_section': undefined
+          public_element_list: 'mocked public_element_list',
+          protected_element_list: undefined,
+          algorithm_section: undefined,
+          equation_section: undefined
         },
         {
-          'public_element_list': undefined,
-          'protected_element_list': 'mocked protected_element_list',
-          'algorithm_section': undefined,
-          'equation_section': undefined
+          public_element_list: undefined,
+          protected_element_list: 'mocked protected_element_list',
+          algorithm_section: undefined,
+          equation_section: undefined
         },
         {
-          'public_element_list': undefined,
-          'protected_element_list': undefined,
-          'algorithm_section': 'mocked algorithm_section',
-          'equation_section': undefined
+          public_element_list: undefined,
+          protected_element_list: undefined,
+          algorithm_section: 'mocked algorithm_section',
+          equation_section: undefined
         },
         {
-          'public_element_list': undefined,
-          'protected_element_list': undefined,
-          'algorithm_section': undefined,
-          'equation_section': 'mocked equation_section'
+          public_element_list: undefined,
+          protected_element_list: undefined,
+          algorithm_section: undefined,
+          equation_section: 'mocked equation_section'
         }
       ]
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
@@ -422,21 +422,21 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'componentReference').returns('mocked component_reference')
       sinon.stub(jq, 'expression').withArgs('test expression1').returns('mocked expression1').withArgs('test expression2').returns('mocked expression2')
 
-      var rawJson = {
-        'component_reference': 'test component_reference',
-        'identifier': 'test.identifier.a',
-        'expression_list': {
-          'expressions': [
+      const rawJson = {
+        component_reference: 'test component_reference',
+        identifier: 'test.identifier.a',
+        expression_list: {
+          expressions: [
             'test expression1',
             'test expression2'
           ]
         }
       }
-      var jsonOutput = jq.externalFunctionCall(rawJson)
-      var referenceJsonOutput = {
-        'component_reference': 'mocked component_reference',
-        'identifier': 'test.identifier.a',
-        'expression_list': [
+      const jsonOutput = jq.externalFunctionCall(rawJson)
+      const referenceJsonOutput = {
+        component_reference: 'mocked component_reference',
+        identifier: 'test.identifier.a',
+        expression_list: [
           'mocked expression1',
           'mocked expression2'
         ]
@@ -448,18 +448,18 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'externalFunctionCall').withArgs('test external_function_call').returns('mocked external_function_call')
       sinon.stub(jq, 'classModification').withArgs('test class_modification').returns('mocked class_modification')
-      var rawJson = {
-        'language_specification': 'test language_specification',
-        'external_function_call': 'test external_function_call',
-        'external_annotation': {
-          'class_modification': 'test class_modification'
+      const rawJson = {
+        language_specification: 'test language_specification',
+        external_function_call: 'test external_function_call',
+        external_annotation: {
+          class_modification: 'test class_modification'
         }
       }
-      var jsonOutput = jq.externalComposition(rawJson)
-      var referenceJsonOutput = {
-        'language_specification': 'test language_specification',
-        'external_function_call': 'mocked external_function_call',
-        'external_annotation': 'mocked class_modification'
+      const jsonOutput = jq.externalComposition(rawJson)
+      const referenceJsonOutput = {
+        language_specification: 'test language_specification',
+        external_function_call: 'mocked external_function_call',
+        external_annotation: 'mocked class_modification'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -469,18 +469,18 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'typeSpecifier').withArgs('test type_specifier').returns('mocked type_specifier')
       sinon.stub(jq, 'arraySubscripts').withArgs('test array_subscripts').returns('mocked array_subscripts')
       sinon.stub(jq, 'componentList').withArgs('test component_list').returns('mocked component_list')
-      var rawJson = {
-        'type_prefix': 'test type_prefix',
-        'type_specifier': 'test type_specifier',
-        'array_subscripts': 'test array_subscripts',
-        'component_list': 'test component_list'
+      const rawJson = {
+        type_prefix: 'test type_prefix',
+        type_specifier: 'test type_specifier',
+        array_subscripts: 'test array_subscripts',
+        component_list: 'test component_list'
       }
-      var jsonOutput = jq.componentClause(rawJson)
-      var referenceJsonOutput = {
-        'type_prefix': 'test type_prefix',
-        'type_specifier': 'mocked type_specifier',
-        'array_subscripts': 'mocked array_subscripts',
-        'component_list': 'mocked component_list'
+      const jsonOutput = jq.componentClause(rawJson)
+      const referenceJsonOutput = {
+        type_prefix: 'test type_prefix',
+        type_specifier: 'mocked type_specifier',
+        array_subscripts: 'mocked array_subscripts',
+        component_list: 'mocked component_list'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -489,18 +489,18 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'nameString').withArgs('test name').returns('mocked name')
       sinon.stub(jq, 'classModification').withArgs('test class_modification').returns('mocked class_modification').withArgs('test annotation.class_modification').returns('mocked annotation.class_modification')
-      var rawJson = {
-        'name': 'test name',
-        'class_modification': 'test class_modification',
-        'annotation': {
-          'class_modification': 'test annotation.class_modification'
+      const rawJson = {
+        name: 'test name',
+        class_modification: 'test class_modification',
+        annotation: {
+          class_modification: 'test annotation.class_modification'
         }
       }
-      var jsonOutput = jq.extendsClause(rawJson)
-      var referenceJsonOutput = {
-        'name': 'mocked name',
-        'class_modification': 'mocked class_modification',
-        'annotation': 'mocked annotation.class_modification'
+      const jsonOutput = jq.extendsClause(rawJson)
+      const referenceJsonOutput = {
+        name: 'mocked name',
+        class_modification: 'mocked class_modification',
+        annotation: 'mocked annotation.class_modification'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -510,20 +510,20 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'nameString').withArgs('test name').returns('mocked name')
       sinon.stub(jq, 'importList').withArgs('test import_list').returns('mocked import_list')
       sinon.stub(jq, 'description').withArgs('test comment').returns('mocked comment').withArgs('test comment').returns('mocked comment')
-      var rawJson = {
-        'identifier': 'test identifier',
-        'name': 'test name',
-        'dot_star': true,
-        'import_list': 'test import_list',
-        'comment': 'test comment'
+      const rawJson = {
+        identifier: 'test identifier',
+        name: 'test name',
+        dot_star: true,
+        import_list: 'test import_list',
+        comment: 'test comment'
       }
-      var jsonOutput = jq.importClause(rawJson)
-      var referenceJsonOutput = {
-        'identifier': 'test identifier',
-        'name': 'mocked name',
-        'dot_star': '.*',
-        'import_list': 'mocked import_list',
-        'description': 'mocked comment'
+      const jsonOutput = jq.importClause(rawJson)
+      const referenceJsonOutput = {
+        identifier: 'test identifier',
+        name: 'mocked name',
+        dot_star: '.*',
+        import_list: 'mocked import_list',
+        description: 'mocked comment'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -533,24 +533,24 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'declaration').withArgs('test declaration').returns('mocked declaration')
       sinon.stub(jq, 'expression').withArgs('test condition_attribute.expression').returns('mocked condition_attribute.expression')
       sinon.stub(jq, 'description').withArgs('test comment').returns('mocked comment').withArgs('test comment').returns('mocked comment')
-      var rawJson = {
-        'component_declaration_list': [
+      const rawJson = {
+        component_declaration_list: [
           {
-            'declaration': 'test declaration',
-            'condition_attribute': {
-              'expression': 'test condition_attribute.expression'
+            declaration: 'test declaration',
+            condition_attribute: {
+              expression: 'test condition_attribute.expression'
             },
-            'comment': 'test comment'
+            comment: 'test comment'
           }
         ]
       }
-      var jsonOutput = jq.componentList(rawJson)
-      var referenceJsonOutput = [{
-        'declaration': 'mocked declaration',
-        'condition_attribute': {
-          'expression': 'mocked condition_attribute.expression'
+      const jsonOutput = jq.componentList(rawJson)
+      const referenceJsonOutput = [{
+        declaration: 'mocked declaration',
+        condition_attribute: {
+          expression: 'mocked condition_attribute.expression'
         },
-        'description': 'mocked comment'
+        description: 'mocked comment'
       }]
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -559,16 +559,16 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'arraySubscripts').withArgs('test array_subscripts').returns('mocked array_subscripts')
       sinon.stub(jq, 'modification').withArgs('test modification').returns('mocked modification')
-      var rawJson = {
-        'identifier': 'test.identifier.a',
-        'array_subscripts': 'test array_subscripts',
-        'modification': 'test modification'
+      const rawJson = {
+        identifier: 'test.identifier.a',
+        array_subscripts: 'test array_subscripts',
+        modification: 'test modification'
       }
-      var jsonOutput = jq.declaration(rawJson)
-      var referenceJsonOutput = {
-        'identifier': 'test.identifier.a',
-        'array_subscripts': 'mocked array_subscripts',
-        'modification': 'mocked modification'
+      const jsonOutput = jq.declaration(rawJson)
+      const referenceJsonOutput = {
+        identifier: 'test.identifier.a',
+        array_subscripts: 'mocked array_subscripts',
+        modification: 'mocked modification'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -578,16 +578,16 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'nameString').withArgs('test name').returns('mocked name')
       sinon.stub(jq, 'modification').withArgs('test modification').returns('mocked modification')
       sinon.stub(graPri, 'graphicAnnotationObj').withArgs('test name', 'test modification').returns('mocked graphicAnnotationObj')
-      var rawJson = {
-        'name': 'test name',
-        'string_comment': 'test string_comment',
-        'modification': 'test modification'
+      const rawJson = {
+        name: 'test name',
+        string_comment: 'test string_comment',
+        modification: 'test modification'
       }
-      var jsonOutput = jq.elementModification(rawJson)
-      var referenceJsonOutput = {
-        'name': 'mocked name',
-        'description_string': 'test string_comment',
-        'modification': 'mocked modification'
+      const jsonOutput = jq.elementModification(rawJson)
+      const referenceJsonOutput = {
+        name: 'mocked name',
+        description_string: 'test string_comment',
+        modification: 'mocked modification'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -595,14 +595,14 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'nameString').withArgs('Line').returns('Line')
       sinon.stub(jq, 'modification').withArgs('test modification').returns('mocked modification')
       sinon.stub(graPri, 'graphicAnnotationObj').withArgs('Line', 'mocked modification').returns('mocked graphicAnnotationObj')
-      var rawJson = {
-        'name': 'Line',
-        'string_comment': 'test string_comment',
-        'modification': 'test modification'
+      const rawJson = {
+        name: 'Line',
+        string_comment: 'test string_comment',
+        modification: 'test modification'
       }
-      var jsonOutput = jq.elementModification(rawJson)
-      var referenceJsonOutput = {
-        'Line': 'mocked graphicAnnotationObj'
+      const jsonOutput = jq.elementModification(rawJson)
+      const referenceJsonOutput = {
+        Line: 'mocked graphicAnnotationObj'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -611,18 +611,18 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'elementModification').withArgs('test element_modification').returns('mocked element_modification')
       sinon.stub(jq, 'elementReplaceable').withArgs('test element_replaceable').returns('mocked element_replaceable')
-      var rawJson = {
-        'each': true,
-        'is_final': true,
-        'element_modification': 'test element_modification',
-        'element_replaceable': 'test element_replaceable'
+      const rawJson = {
+        each: true,
+        is_final: true,
+        element_modification: 'test element_modification',
+        element_replaceable: 'test element_replaceable'
       }
-      var jsonOutput = jq.elementModificationReplaceable(rawJson)
-      var referenceJsonOutput = {
-        'each': true,
-        'final': true,
-        'element_modification': 'mocked element_modification',
-        'element_replaceable': 'mocked element_replaceable'
+      const jsonOutput = jq.elementModificationReplaceable(rawJson)
+      const referenceJsonOutput = {
+        each: true,
+        final: true,
+        element_modification: 'mocked element_modification',
+        element_replaceable: 'mocked element_replaceable'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -632,20 +632,20 @@ mo.describe('jsonquery.js', function () {
       sinon.stub(jq, 'shortClassDefinition').withArgs('test short_class_definition').returns('mocked short_class_definition')
       sinon.stub(jq, 'componentClause1').withArgs('test component_clause1').returns('mocked component_clause1')
       sinon.stub(jq, 'elementReplaceable').withArgs('test element_replaceable').returns('mocked element_replaceable')
-      var rawJson = {
-        'each': true,
-        'is_final': true,
-        'short_class_definition': 'test short_class_definition',
-        'component_clause1': 'test component_clause1',
-        'element_replaceable': 'test element_replaceable'
+      const rawJson = {
+        each: true,
+        is_final: true,
+        short_class_definition: 'test short_class_definition',
+        component_clause1: 'test component_clause1',
+        element_replaceable: 'test element_replaceable'
       }
-      var jsonOutput = jq.elementRedeclaration(rawJson)
-      var referenceJsonOutput = {
-        'each': true,
-        'final': true,
-        'short_class_definition': 'mocked short_class_definition',
-        'component_clause1': 'mocked component_clause1',
-        'element_replaceable': 'mocked element_replaceable'
+      const jsonOutput = jq.elementRedeclaration(rawJson)
+      const referenceJsonOutput = {
+        each: true,
+        final: true,
+        short_class_definition: 'mocked short_class_definition',
+        component_clause1: 'mocked component_clause1',
+        element_replaceable: 'mocked element_replaceable'
       }
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
@@ -654,27 +654,27 @@ mo.describe('jsonquery.js', function () {
     mo.it('testing structure', function () {
       sinon.stub(jq, 'simpleExpression').withArgs('test simple_expression1').returns('mocked simple_expression1').withArgs('test simple_expression2').returns('mocked simple_expression2')
       sinon.stub(jq, 'ifExpString').withArgs('test if_expression1').returns('mocked if_expression1').withArgs('test if_expression2').returns('mocked if_expression2')
-      var rawJson = [
+      const rawJson = [
         {
-          'expressions': [
+          expressions: [
             {
-              'simple_expression': 'test simple_expression1'
+              simple_expression: 'test simple_expression1'
             }, {
-              'if_expression': 'test if_expression1'
+              if_expression: 'test if_expression1'
             }
           ]
         }, {
-          'expressions': [
+          expressions: [
             {
-              'simple_expression': 'test simple_expression2'
+              simple_expression: 'test simple_expression2'
             }, {
-              'if_expression': 'test if_expression2'
+              if_expression: 'test if_expression2'
             }
           ]
         }
       ]
-      var jsonOutput = jq.expLisString(rawJson)
-      var referenceJsonOutput = 'mocked simple_expression1,mocked if_expression1;mocked simple_expression2,mocked if_expression2'
+      const jsonOutput = jq.expLisString(rawJson)
+      const referenceJsonOutput = 'mocked simple_expression1,mocked if_expression1;mocked simple_expression2,mocked if_expression2'
       as.equal(equalObjects(jsonOutput, referenceJsonOutput), true, 'expected =' + JSON.stringify(referenceJsonOutput) + '; actual =' + JSON.stringify(jsonOutput))
     })
   })

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -7,7 +7,7 @@ const ut = require('../lib/util')
 const Promise = require('bluebird')
 const fs = Promise.promisifyAll(require('fs'))
 const glob = require('glob-promise')
-var logger = require('winston')
+const logger = require('winston')
 // const cheerio = require('cheerio')
 
 logger.configure({
@@ -24,8 +24,8 @@ logger.level = 'error'
 
 /** Function to get all the Modelica files to be tested
   */
-var getIntFiles = function (mode) {
-  var pattern
+const getIntFiles = function (mode) {
+  let pattern
   if (mode === 'cdl') {
     pattern = path.join(__dirname, 'FromModelica', '*.mo')
     return glob.sync(pattern)
@@ -36,8 +36,8 @@ var getIntFiles = function (mode) {
 
 /** Function that checks parsing from Modelica to JSON, in 'cdl' parsing mode
   */
-var checkCdlJSON = function (outFormat, extension, message) {
-  var mode = 'cdl'
+const checkCdlJSON = function (outFormat, extension, message) {
+  const mode = 'cdl'
   // process.env.MODELICAPATH = __dirname
   mo.it(message, () => {
     // mo files array to be tested.
@@ -46,17 +46,17 @@ var checkCdlJSON = function (outFormat, extension, message) {
       return !obj.includes('Extends')
     })
     // Name of subpackage to store json output files
-    var subPackName = (outFormat === 'raw-json' ? 'raw-json' : 'json')
+    const subPackName = (outFormat === 'raw-json' ? 'raw-json' : 'json')
     // When parsing mode is 'cdl', the moFiles should feed into parser one-by-one
 
-    var expectedOutputPath = path.join(process.cwd(), 'test', 'reference')
+    const expectedOutputPath = path.join(process.cwd(), 'test', 'reference')
 
     testMoFiles.map(fil => {
       // 'fil.split()' changes string 'fil' to be string array with single element
       // 'fil' is like '../test/FromModelica/***.mo'
       // const jsonNewCDL = pa.getJSON(fil.split(), mode, outFormat)
       pa.getJsons([fil], mode, outFormat, 'current', 'false')
-      var idx = fil.lastIndexOf(path.sep)
+      const idx = fil.lastIndexOf(path.sep)
       const jsonNewCDLFile = path.join(process.cwd(), subPackName, 'test', 'FromModelica', fil.slice(idx + 1, -3) + extension)
 
       // Read the stored json representation from disk
@@ -74,10 +74,10 @@ var checkCdlJSON = function (outFormat, extension, message) {
       // Update the path to be relative to the project home.
       // This is needed for the regression tests to be portable.
       if (oldCDL.modelicaFile) {
-        oldCDL['fullMoFilePath'] = oldCDL['modelicaFile'].split('modelica-json/')[1]
+        oldCDL.fullMoFilePath = oldCDL.modelicaFile.split('modelica-json/')[1]
       }
       if (neCDL.modelicaFile) {
-        neCDL['fullMoFilePath'] = neCDL['modelicaFile'].split('modelica-json/')[1]
+        neCDL.fullMoFilePath = neCDL.modelicaFile.split('modelica-json/')[1]
       }
       const tempOld = JSON.stringify(oldCDL)
       const tempNew = JSON.stringify(neCDL)
@@ -90,9 +90,9 @@ var checkCdlJSON = function (outFormat, extension, message) {
 
 /** Function that checks parsing from Modelica to JSON, in 'modelica' parsing mode
   */
- // TODO: modify this
-var checkModJSON = function (outFormat, extension, message) {
-  var mode = 'modelica'
+// TODO: modify this
+const checkModJSON = function (outFormat, extension, message) {
+  const mode = 'modelica'
   // process.env.MODELICAPATH = __dirname
   mo.it(message, () => {
     // mo files package to be tested
@@ -100,28 +100,28 @@ var checkModJSON = function (outFormat, extension, message) {
     const testMoFiles = ut.getMoFiles(testMoFilesTemp)
 
     // Name of subpackage to store json output files
-    var subPackName = (outFormat === 'raw-json' ? 'raw-json' : 'json')
+    const subPackName = (outFormat === 'raw-json' ? 'raw-json' : 'json')
     // When parsing mode is 'modelica', the moFiles should feed into parser in package
     // const jsonNewMOD = pa.getJSON(testMoFiles, mode, outFormat)
     pa.getJsons(testMoFiles, mode, outFormat, 'current', 'false')
-    var pattern = path.join('test', 'FromModelica', '*.mo')
-    var files = glob.sync(pattern)
-    var expectedOutputPath = path.join(process.cwd(), 'test', 'reference')
+    const pattern = path.join('test', 'FromModelica', '*.mo')
+    const files = glob.sync(pattern)
+    const expectedOutputPath = path.join(process.cwd(), 'test', 'reference')
 
-    for (var i = 0; i < files.length; i++) {
-      var idx2 = files[i].lastIndexOf(path.sep)
+    for (let i = 0; i < files.length; i++) {
+      const idx2 = files[i].lastIndexOf(path.sep)
       const fileNameMOD = files[i].slice(idx2 + 1, -3) + extension
       const oldFileMOD = path.join(expectedOutputPath, subPackName, 'test', 'FromModelica', fileNameMOD)
       // Read the old json
       const jsonOldMOD = JSON.parse(fs.readFileSync(oldFileMOD, 'utf8'))
 
       if (jsonOldMOD.modelicaFile) {
-        jsonOldMOD['fullMoFilePath'] = jsonOldMOD['modelicaFile'].split('modelica-json/')[1]
+        jsonOldMOD.fullMoFilePath = jsonOldMOD.modelicaFile.split('modelica-json/')[1]
       }
       const jsonNewMOD = path.join(expectedOutputPath, subPackName, 'test', 'FromModelica', fileNameMOD)
-      var neMOD = JSON.parse(fs.readFileSync(jsonNewMOD, 'utf8'))
+      const neMOD = JSON.parse(fs.readFileSync(jsonNewMOD, 'utf8'))
       if (neMOD.modelicaFile) {
-        neMOD['fullMoFilePath'] = neMOD['modelicaFile'].split('modelica-json/')[1]
+        neMOD.fullMoFilePath = neMOD.modelicaFile.split('modelica-json/')[1]
       }
 
       const tempOld = JSON.stringify(jsonOldMOD)

--- a/validation.js
+++ b/validation.js
@@ -5,14 +5,14 @@ const fs = require('fs')
 const ArgumentParser = require('argparse').ArgumentParser
 /// ///////////////////////////////////////
 
-var validation = new ArgumentParser({
+const validation = new ArgumentParser({
   version: '0.0.1',
   addHelp: true,
   description: 'Json file validation against schema'
 })
 
 validation.addArgument(
-  [ '-m', '--mode' ],
+  ['-m', '--mode'],
   {
     help: "Parsing mode, single CDL model or buildings modelica library package, 'cdl' is the default.",
     choices: ['cdl', 'modelica'],
@@ -21,14 +21,14 @@ validation.addArgument(
 )
 
 validation.addArgument(
-  [ '-f', '--file' ],
+  ['-f', '--file'],
   {
     help: 'JSON file to test against schema',
     required: true
   }
 )
 
-var args = validation.parseArgs()
+const args = validation.parseArgs()
 
 const logFile = 'validation.log'
 try {


### PR DESCRIPTION
This closes #203.

- [x] fixed the logical expression
- [x] update the standard version from version 10, to 17, the latest version, see https://www.npmjs.com/package/standard.

By running the `npx standard`, we will still see the warning:
```
jianjunhu@ubuntu:~/GitFolder/modelica-json$ npx standard
standard: Use JavaScript Standard Style (https://standardjs.com)
  /home/jianjunhu/GitFolder/modelica-json/test/test_jsonquery.js:21:5: Invalid loop. Its body allows only one iteration. (no-unreachable-loop)
  /home/jianjunhu/GitFolder/modelica-json/test/test_parser.js:54:25: Array.prototype.map() expects a return value from arrow function. (array-callback-return)
```
This would need to be addressed in separated issue.