### PR TITLE
Issue222 instruction

### DIFF
--- a/InstallOnWindows.bat
+++ b/InstallOnWindows.bat
@@ -11,6 +11,7 @@
 :: versions of JRE, add the higher version JRE path to the top of your "Path" environment
 
 :: Download and install Node.js: https://nodejs.org/en/download/
+:: Add nodejs folder to your "Path" environment
 
 :: set MODELICAPATH
 
@@ -19,7 +20,7 @@
 ::*******************************************************************
 :: Download maven
 echo ----------- Downloading Apache Maven ----------- 
-set MVNLink=https://dlcdn.apache.org/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip
+set MVNLink=https://archive.apache.org/dist/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.zip
 set MVNZip=%CD%\apache_maven.zip
 bitsadmin /transfer "Downloading MVN" %MVNLink% %MVNZip%
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ make clean-installation
 
 - Install [Java SE Development Kit (64-bit version)](https://www.oracle.com/java/technologies/javase-downloads.html), [Java Runtime Environment (64-bit version)](https://java.com/en/download/manual.jsp) and [Node.js](https://nodejs.org/en/download/).
 
+- Add `path\to\your\nodejs` to the `Path` environment.
+
 - In batch file `InstallOnWindows.bat`, update `JAVA_HOME` path in line `set JAVA_HOME=path\to\your\jdk`.
 
 - Finally, to install dependencies and compile the Java files, run `InstallOnWindows.bat`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Logging level. The choices are `error`, `warn`, `info` (default), `verbose`, `de
 
 Specify the output directory. The default option is the current directory.
 
+##### --prettyPrint / -p
+
+Boolean flag to specify if prettyprint the JSON output. The default option is `false`.
+
+
 ## 4. JSON Schemas
 
 The JSON representation of Modelica and CDL models must be compliant with the corresponding JSON Schema. This is applicable for the JSON output, not for the raw-json one.

--- a/app.js
+++ b/app.js
@@ -116,7 +116,7 @@ if (args.output === 'json') {
   } else {
     schema = path.join(`${__dirname}`, 'schema-modelica.json')
   }
-  let jsonDir = (args.directory === 'current') ? outDir = process.cwd() : args.directory
+  const jsonDir = (args.directory === 'current') ? process.cwd() : args.directory
   let jsonFiles = ut.findFilesInDir(path.join(jsonDir, 'json'), '.json')
   // exclude CDL folder and possibly Modelica folder
   const pathSep = path.sep

--- a/app.js
+++ b/app.js
@@ -116,7 +116,8 @@ if (args.output === 'json') {
   } else {
     schema = path.join(`${__dirname}`, 'schema-modelica.json')
   }
-  let jsonFiles = ut.findFilesInDir(path.join(args.directory, 'json'), '.json')
+  let jsonDir = (args.directory === 'current') ? outDir = process.cwd() : args.directory
+  let jsonFiles = ut.findFilesInDir(path.join(jsonDir, 'json'), '.json')
   // exclude CDL folder and possibly Modelica folder
   const pathSep = path.sep
   const cdlPath = path.join(pathSep, 'CDL', pathSep)

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,8 +11,9 @@ const Ajv = require('ajv')
  * element. Elements are separated by ':'
  */
 function getMODELICAPATH () {
+  let splitMark = process.platform.includes('win') ? ';' : ':'
   return (process.env.MODELICAPATH)
-    ? (process.cwd() + ':' + process.env.MODELICAPATH).split(':')
+    ? (process.cwd() + splitMark + process.env.MODELICAPATH).split(splitMark)
     : [process.cwd()]
 }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -11,9 +11,9 @@ const Ajv = require('ajv')
  * element. Elements are separated by ':'
  */
 function getMODELICAPATH () {
-  let splitMark = process.platform.includes('win') ? ';' : ':'
+  const spe = process.platform.includes('win') ? ';' : ':'
   return (process.env.MODELICAPATH)
-    ? (process.cwd() + splitMark + process.env.MODELICAPATH).split(splitMark)
+    ? (process.cwd() + spe + process.env.MODELICAPATH).split(spe)
     : [process.cwd()]
 }
 


### PR DESCRIPTION
This closes #222.

- [x] updated maven link in the windows batch file,
- [x] updated installation instruction on Windows OS,
- [x] fixed bug as previously the output directory has to be specified and cannot be specified as `"current"`,
- [x] fixed the bug when parsing class in Windows OS. Previously it cannot find the `.mo` file, as `":"` and `";"` are used as the separator in the `Path` environment variable on `Ubuntu` and `WindowsOS`.