### PR TITLE
Address Issue #318

### DIFF
--- a/InstallOnWindows.bat
+++ b/InstallOnWindows.bat
@@ -8,7 +8,6 @@
 
 :: set MODELICAPATH
 
-cd..
 :: Install node package
 echo ----------- Installing node package -----------
 CALL npm install --save


### PR DESCRIPTION
Based on issue #318 

During the Windows installation, the required `\node-modules` folder will be generated inside '\modelica-json` by referencing the packages in `\modelica-json\package.json`

Feel free to ignore if a better solution is found